### PR TITLE
feat: allow many context in bugTitle

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -1089,7 +1089,9 @@ components:
           type: string
           description: Bug title without context.
         context:
-          type: string
+          type: array
+          items:
+            type: string
       required:
         - full
         - compact

--- a/src/routes/campaigns/campaignId/bugs/bugId/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/index.spec.ts
@@ -446,7 +446,7 @@ describe("GET /campaigns/{cid}/bugs/{bid}", () => {
       expect.objectContaining({
         full: "[CON-TEXT][2ndContext] - Bug 12-999 message",
         compact: "Bug 12-999 message",
-        context: "CON-TEXT - 2ndContext",
+        context: ["CON-TEXT", "2ndContext"],
       })
     );
   });

--- a/src/routes/campaigns/campaignId/bugs/bugId/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/index.spec.ts
@@ -106,7 +106,7 @@ const bug_1: BugsParams = {
   id: 12999,
   internal_id: "UG12999",
   wp_user_id: 1,
-  message: "[CON-TEXT] - Bug 12-999 message",
+  message: "[CON-TEXT][2ndContext] - Bug 12-999 message",
   description: "Bug 12999 description",
   expected_result: "Bug 12999 expected result",
   current_result: "Bug 12999 actual result",
@@ -442,12 +442,11 @@ describe("GET /campaigns/{cid}/bugs/{bid}", () => {
       .get(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
       .set("Authorization", "Bearer customer");
     expect(response.status).toBe(200);
-
     expect(response.body.title).toEqual(
       expect.objectContaining({
-        full: "[CON-TEXT] - Bug 12-999 message",
+        full: "[CON-TEXT][2ndContext] - Bug 12-999 message",
         compact: "Bug 12-999 message",
-        context: "CON-TEXT",
+        context: "CON-TEXT - 2ndContext",
       })
     );
   });

--- a/src/routes/campaigns/campaignId/bugs/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/index.spec.ts
@@ -610,7 +610,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
     expect(response.body.items[1].title).toEqual({
       full: bug_1.message,
       compact: "Bug 1 super-message",
-      context: "CON-TEXT",
+      context: ["CON-TEXT"],
     });
   });
 

--- a/src/routes/campaigns/campaignId/bugs/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/index.spec.ts
@@ -103,6 +103,19 @@ const campaign_4 = {
   project_id: project_1.id,
   cust_bug_vis: 1,
 };
+const campaign_5 = {
+  id: 5,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 5 title - no title rule",
+  customer_title: "Campaign 5 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: project_1.id,
+};
 
 const device_1: DeviceParams = {
   id: 12,
@@ -240,6 +253,30 @@ const bug_6_pending: BugsParams = {
   status_id: 1, // pending
 };
 
+const bug_7: BugsParams = {
+  id: 7,
+  internal_id: "BUG7",
+  message: "Bug 7 message",
+  description: "Bug 7 description",
+  expected_result: "Bug 7 expected result",
+  current_result: "Bug 7 current result",
+  campaign_id: campaign_5.id,
+  bug_type_id: 1,
+  bug_replicability_id: 1,
+  status_id: 2,
+  status_reason: "Bug 7 status reason",
+  application_section: "Bug 7 application section",
+  note: "Bug 7 note - this is a bug with no context",
+  wp_user_id: 1,
+  is_favorite: 1,
+  dev_id: device_1.id,
+  manufacturer: device_1.manufacturer,
+  model: device_1.model,
+  os: device_1.operating_system,
+  os_version: device_1.os_version,
+  severity_id: 2,
+};
+
 const bug_media_1 = {
   id: 123,
   bug_id: bug_1.id,
@@ -261,7 +298,13 @@ describe("GET /campaigns/{cid}/bugs", () => {
           projects: [project_1, project_2],
           userToProjects: [user_to_project_1],
           campaignTypes: [campaign_type_1],
-          campaigns: [campaign_1, campaign_2, campaign_3, campaign_4],
+          campaigns: [
+            campaign_1,
+            campaign_2,
+            campaign_3,
+            campaign_4,
+            campaign_5,
+          ],
         });
         await CampaignMeta.mock();
         await CampaignMeta.insert({
@@ -284,6 +327,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
         await bugs.insert(bug_4);
         await bugs.insert(bug_5);
         await bugs.insert(bug_6_pending);
+        await bugs.insert(bug_7);
         await bugMedia.insert(bug_media_1);
         await bugSeverity.addDefaultItems();
         await bugReplicability.addDefaultItems();
@@ -641,6 +685,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
       ])
     );
   });
+
   it("Should return need review bugs if option is not enabled but user is admin", async () => {
     const response = await request(app)
       .get(`/campaigns/${campaign_1.id}/bugs`)
@@ -678,6 +723,17 @@ describe("GET /campaigns/{cid}/bugs", () => {
         expect.objectContaining({ id: bug_6_pending.id }),
       ])
     );
+  });
+
+  it("Should bugs without context if title_rule is not active", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_5.id}/bugs`)
+      .set("Authorization", "Bearer customer");
+      console.log("CP5",response.body.items);
+    expect(response.body.items[0].title).toEqual({
+      full: bug_7.message,
+      compact: bug_7.message,
+    });
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/index.spec.ts
@@ -714,7 +714,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
 
   it("Should NOT return pending bugs", async () => {
     const response = await request(app)
-      .get(`/campaigns/${campaign_4.id}/bugs`)
+      .get(`/campaigns/${campaign_5.id}/bugs`)
       .set("Authorization", "Bearer customer");
 
     expect(response.body.items.length).toBe(1);

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -269,7 +269,7 @@ export interface components {
       full: string;
       /** @description Bug title without context. */
       compact: string;
-      context?: string;
+      context?: string[];
     };
     /** BugType */
     BugType: {

--- a/src/utils/campaigns/getTitleRule/index.ts
+++ b/src/utils/campaigns/getTitleRule/index.ts
@@ -35,15 +35,14 @@ export const getBugTitle = ({
         .replace(bugTitle.match(/\[(.*?)\]/)![0], "")
         .replace("-", "")
         .trim(),
-      context: bugTitle.match(/\[(.*?)\]/)![1],
+      context: [bugTitle.match(/\[(.*?)\]/)![1]],
     };
     while (res.compact.match(/\[(.*?)\]/)) {
       const newContext = res.compact.match(/\[(.*?)\]/)![0].trim();
-      res.context = [res.context, res.compact.match(/\[(.*?)\]/)![1]].join(
-        " - "
-      );
+      res.context.push(res.compact.match(/\[(.*?)\]/)![1]);
       res.compact = res.compact.replace(newContext, "").trim();
     }
+    console.log(res);
     return res;
   }
 

--- a/src/utils/campaigns/getTitleRule/index.ts
+++ b/src/utils/campaigns/getTitleRule/index.ts
@@ -29,7 +29,7 @@ export const getBugTitle = ({
   if (hasTitleRule) {
     if (!bugTitle.match(/\[(.*?)\]/)) return formattedBugTitle;
 
-    return {
+    let res = {
       ...formattedBugTitle,
       compact: bugTitle
         .replace(bugTitle.match(/\[(.*?)\]/)![0], "")
@@ -37,6 +37,14 @@ export const getBugTitle = ({
         .trim(),
       context: bugTitle.match(/\[(.*?)\]/)![1],
     };
+    while (res.compact.match(/\[(.*?)\]/)) {
+      const newContext = res.compact.match(/\[(.*?)\]/)![0].trim();
+      res.context = [res.context, res.compact.match(/\[(.*?)\]/)![1]].join(
+        " - "
+      );
+      res.compact = res.compact.replace(newContext, "").trim();
+    }
+    return res;
   }
 
   return formattedBugTitle;

--- a/src/utils/campaigns/getTitleRule/index.ts
+++ b/src/utils/campaigns/getTitleRule/index.ts
@@ -42,7 +42,6 @@ export const getBugTitle = ({
       res.context.push(res.compact.match(/\[(.*?)\]/)![1]);
       res.compact = res.compact.replace(newContext, "").trim();
     }
-    console.log(res);
     return res;
   }
 

--- a/src/utils/campaigns/getTitleRule/index.ts
+++ b/src/utils/campaigns/getTitleRule/index.ts
@@ -28,21 +28,16 @@ export const getBugTitle = ({
 
   if (hasTitleRule) {
     if (!bugTitle.match(/\[(.*?)\]/)) return formattedBugTitle;
-
-    let res = {
+    return {
       ...formattedBugTitle,
       compact: bugTitle
-        .replace(bugTitle.match(/\[(.*?)\]/)![0], "")
+        .replace(bugTitle.match(/\[(.*?)\]/g)!?.join(""), "")
         .replace("-", "")
         .trim(),
-      context: [bugTitle.match(/\[(.*?)\]/)![1]],
+      context: bugTitle
+        .match(/\[(.*?)\]/g)
+        ?.map((item) => item.replace(/[\[\]]/g, "")),
     };
-    while (res.compact.match(/\[(.*?)\]/)) {
-      const newContext = res.compact.match(/\[(.*?)\]/)![0].trim();
-      res.context.push(res.compact.match(/\[(.*?)\]/)![1]);
-      res.compact = res.compact.replace(newContext, "").trim();
-    }
-    return res;
   }
 
   return formattedBugTitle;


### PR DESCRIPTION
Allow many context for bugtitle. Return contexts as array.
 - Expected Result Case oneContext:
   - full: [context1] - Bug title
   - compact: Bug title
   - context: ["context1"]
 - Expected Result manyContext:
   - full: [context1][context2] - Bug title
   - compact: Bug title
   - context: ["context1","context2"]