### PR TITLE
Cup 1407 add stats endpoint

### DIFF
--- a/src/__mocks__/database/tryber_table.ts
+++ b/src/__mocks__/database/tryber_table.ts
@@ -26,6 +26,11 @@ class Table<T> {
     return await db.run(`DELETE FROM ${this.name}`);
   }
 
+  async delete(where: (T | T[])[]) {
+    const WHERE = this._getWhere(where);
+    return await db.run(`DELETE FROM ${this.name} ${WHERE}`);
+  }
+
   _getWhere(where?: (T | T[])[]): string {
     let WHERE = "";
     if (where) {

--- a/src/__mocks__/database/tryber_table.ts
+++ b/src/__mocks__/database/tryber_table.ts
@@ -25,12 +25,8 @@ class Table<T> {
   async clear() {
     return await db.run(`DELETE FROM ${this.name}`);
   }
-  async all(
-    params?: (keyof T)[],
-    where?: (T | T[])[],
-    limit?: number
-  ): Promise<T[]> {
-    const keys = params ? params.join(",") : "*";
+
+  _getWhere(where?: (T | T[])[]): string {
     let WHERE = "";
     if (where) {
       const orQueries = where.map((item) => {
@@ -52,6 +48,36 @@ class Table<T> {
         )
         .join(" AND ")}`;
     }
+
+    return WHERE;
+  }
+
+  async update(params: T[], where: (T | T[])[]) {
+    const set = params
+      .map((item) => {
+        if (item && Object.keys(item).length > 0) {
+          const keys = Object.keys(item);
+          const values = Object.values(item);
+          return keys
+            .map((key, index) => `${key}='${values[index]}'`)
+            .join(", ");
+        }
+      })
+      .join();
+
+    const WHERE = this._getWhere(where);
+
+    return await db.run(`UPDATE ${this.name} SET ${set} ${WHERE}`);
+  }
+
+  async all(
+    params?: (keyof T)[],
+    where?: (T | T[])[],
+    limit?: number
+  ): Promise<T[]> {
+    const keys = params ? params.join(",") : "*";
+    const WHERE = this._getWhere(where);
+
     return await db.all(
       `SELECT ${keys} FROM ${this.name} ${WHERE} ${
         limit ? `LIMIT ${limit}` : ""

--- a/src/__mocks__/database/use_cases.ts
+++ b/src/__mocks__/database/use_cases.ts
@@ -12,6 +12,9 @@ type UseCaseParams = {
   position?: number;
   allow_media?: number;
   optimize_media?: number;
+  simple_title?: string;
+  info?: string;
+  prefix?: string;
 };
 
 const defaultItem: UseCaseParams = {
@@ -25,12 +28,15 @@ const defaultItem: UseCaseParams = {
   position: 0,
   allow_media: 0,
   optimize_media: 0,
+  simple_title: "",
+  info: "",
+  prefix: "",
 };
 class UseCases extends Table<UseCaseParams> {
   protected name = "wp_appq_campaign_task";
   protected columns = [
     "id INTEGER PRIMARY KEY AUTOINCREMENT",
-    "title VARCHAR(140)",
+    "title VARCHAR(512)",
     "content TEXT",
     "campaign_id INTEGER",
     "is_required INTEGER",
@@ -40,6 +46,9 @@ class UseCases extends Table<UseCaseParams> {
     "position INTEGER DEFAULT 0 NOT NULL",
     "allow_media INTEGER DEFAULT 0 NOT NULL",
     "optimize_media INTEGER DEFAULT 0 NOT NULL",
+    "simple_title VARCHAR(128) NOT NULL",
+    "info VARCHAR(256) NOT NULL",
+    "prefix VARCHAR(128) NOT NULL",
   ];
   constructor() {
     super(defaultItem);

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -138,13 +138,16 @@ paths:
                   total:
                     type: integer
               examples:
-                example-1:
+                Example 1:
                   value:
                     items:
                       - id: 0
                         internal_id: string
                         campaign_id: 0
-                        title: string
+                        title:
+                          full: string
+                          compact: string
+                          context: string
                         step_by_step: string
                         expected_result: string
                         current_result: string
@@ -160,14 +163,15 @@ paths:
                         replicability:
                           id: 0
                           name: string
-                        created: '2019-08-24T14:15:22Z'
-                        updated: '2019-08-24T14:15:22Z'
+                        created: string
+                        updated: string
                         note: string
                         device:
-                          desktop_type: Gaming PC
-                          os: Windows
-                          os_version: Windows 10 May 2021 Update (19043)
-                          type: desktop
+                          manufacturer: string
+                          model: string
+                          os: string
+                          os_version: string
+                          type: smartphone
                         application_section:
                           id: 0
                           title: string
@@ -253,6 +257,26 @@ paths:
                   $ref: '#/components/schemas/Report'
       operationId: get-campaigns-reports
       description: Return all available report of a specific campaign
+      security:
+        - JWT: []
+  '/campaigns/{cid}/widgets/{wslug}':
+    parameters:
+      - $ref: '#/components/parameters/cid'
+      - $ref: '#/components/parameters/wslug'
+    get:
+      summary: Get Campaign widget data
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/WidgetBugsByUseCase'
+                  - $ref: '#/components/schemas/WidgetBugsByDevice'
+              examples: {}
+      operationId: get-campaigns-cid-widgets-wslug
       security:
         - JWT: []
   /projects:
@@ -1559,6 +1583,7 @@ components:
       required:
         - title
         - description
+      description: ''
     User:
       title: User
       type: object
@@ -1670,6 +1695,92 @@ components:
         - csm
       x-tags:
         - workspace
+    WidgetBugsByUseCase:
+      title: WidgetBugsByUseCase
+      x-stoplight:
+        id: tm59wsbormo47
+      type: object
+      x-examples:
+        Example 1:
+          data:
+            - title: Navigazione Sito
+              description: aasdasdsa
+              uniqueBugs: 10
+              bugs: 12
+            - title: HomePage
+              description: aasdasdsa
+              uniqueBugs: 1
+              bugs: 3
+            - title: Product List
+              description: lorem ipsum
+              uniqueBugs: 0
+              bugs: 0
+          kind: bugsByUseCase
+      description: Returns a list of use case with the number of bugs
+      properties:
+        data:
+          type: array
+          items:
+            allOf:
+              - $ref: '#/components/schemas/UseCase'
+              - type: object
+                properties:
+                  bugs:
+                    type: integer
+                    description: Unique bugs
+                required:
+                  - bugs
+        kind:
+          type: string
+          enum:
+            - bugsByUseCase
+      required:
+        - data
+        - kind
+    WidgetBugsByDevice:
+      title: WidgetBugsByDevice
+      x-stoplight:
+        id: tm59wsbormo47
+      type: object
+      x-examples:
+        Example 1:
+          data:
+            - manufacturer: Samsung
+              model: Galaxy S22 Ultra
+              os: Android
+              os_version: '13'
+              type: smartphone
+              bugs: 12
+            - desktop_type: Gaming PC
+              os: Windows
+              os_version: Windows 10 May 2021 Update (19043)
+              type: desktop
+              bugs: 4
+          kind: bugsByUseCase
+      description: Returns a list of devices with the number of bugs
+      properties:
+        data:
+          type: array
+          items:
+            allOf:
+              - oneOf:
+                  - $ref: '#/components/schemas/Smartphone'
+                  - $ref: '#/components/schemas/Desktop'
+                  - $ref: '#/components/schemas/Tablet'
+              - type: object
+                properties:
+                  bugs:
+                    type: integer
+                    description: Unique bugs
+                required:
+                  - bugs
+        kind:
+          type: string
+          enum:
+            - bugsByDevice
+      required:
+        - data
+        - kind
   securitySchemes:
     JWT:
       type: http
@@ -1745,6 +1856,13 @@ components:
       schema:
         type: string
       description: Defines an identifier for the bug object (BUG ID)
+    wslug:
+      name: wslug
+      in: path
+      required: true
+      schema:
+        type: string
+      description: Campaign widget slug
   requestBodies:
     Credentials:
       content:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -1871,7 +1871,7 @@ components:
         type: string
       description: Defines an identifier for the bug object (BUG ID)
     wslug:
-      name: wslug
+      name: s
       in: query
       required: true
       schema:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -1742,8 +1742,11 @@ components:
                   bugs:
                     type: integer
                     description: Unique bugs
+                  usecase_id:
+                    type: number
                 required:
                   - bugs
+                  - usecase_id
         kind:
           type: string
           enum:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -276,6 +276,12 @@ paths:
                   - $ref: '#/components/schemas/WidgetBugsByUseCase'
                   - $ref: '#/components/schemas/WidgetBugsByDevice'
               examples: {}
+        '401':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
       operationId: get-campaigns-cid-widgets-wslug
       security:
         - JWT: []

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -259,10 +259,14 @@ paths:
       description: Return all available report of a specific campaign
       security:
         - JWT: []
-  '/campaigns/{cid}/widgets/{wslug}':
+  '/campaigns/{cid}/widgets':
     parameters:
-      - $ref: '#/components/parameters/cid'
-      - $ref: '#/components/parameters/wslug'
+      - name: cid
+        in: path
+        required: true
+        schema:
+          type: number
+        description: Campaign id
     get:
       summary: Get Campaign widget data
       tags: []
@@ -285,6 +289,8 @@ paths:
       operationId: get-campaigns-cid-widgets-wslug
       security:
         - JWT: []
+      parameters:
+        - $ref: '#/components/parameters/wslug'
   /projects:
     post:
       summary: Create a new project
@@ -1864,10 +1870,14 @@ components:
       description: Defines an identifier for the bug object (BUG ID)
     wslug:
       name: wslug
-      in: path
+      in: query
       required: true
       schema:
         type: string
+        enum:
+          - bugs-by-usecase
+          - bugs-by-device
+          - bugs-by-type
       description: Campaign widget slug
   requestBodies:
     Credentials:

--- a/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
@@ -330,8 +330,6 @@ describe("GET /campaigns/{cid}/widgets", () => {
     expect(response.status).toBe(200);
     expect(response.body.kind).toEqual("bugsByDevice");
     expect(response.body.data[0].bugs).toEqual(2);
-
-    console.log(response.body.data[0].bugs);
   });
 
   it("Should answer 200 and return the bugs by device widget (with 2 device type)", async () => {

--- a/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
@@ -298,6 +298,13 @@ describe("GET /campaigns/{cid}/widgets", () => {
       application_section_id: useCase2.id,
     };
 
+    const bug_without_usecase = {
+      ...bug_1,
+      id: 4,
+      application_section: "asd",
+      application_section_id: -1,
+    };
+
     beforeAll(async () => {
       return new Promise(async (resolve, reject) => {
         try {
@@ -317,6 +324,7 @@ describe("GET /campaigns/{cid}/widgets", () => {
         try {
           await useCases.delete([{ id: useCase2.id }]);
           await bugs.delete([{ id: bug_3.id }]);
+          await bugs.delete([{ id: bug_without_usecase.id }]);
         } catch (error) {
           console.error(error);
           reject(error);
@@ -346,6 +354,20 @@ describe("GET /campaigns/{cid}/widgets", () => {
 
       expect(response.body.data[1].title).toEqual(useCase2.title);
       expect(response.body.data[1].bugs).toEqual(1);
+    });
+
+    it("Should answer 200 and returns bugs even without any usecase specified", async () => {
+      await bugs.insert(bug_without_usecase);
+
+      const response = await request(app)
+        .get(`/campaigns/${campaign_1.id}/widgets?s=bugs-by-usecase`)
+        .set("Authorization", "Bearer customer");
+      expect(response.status).toBe(200);
+      expect(response.body.kind).toEqual("bugsByUseCase");
+
+      expect(response.body.data[2].usecase_id).toEqual(-1);
+      expect(response.body.data[2].title).toEqual("Not a specific use case");
+      expect(response.body.data[2].bugs).toEqual(1);
     });
 
     // --- End of describe "Bugs by usecase"

--- a/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
@@ -88,6 +88,27 @@ const device_1: DeviceParams = {
   form_factor: "Smartphone",
 };
 
+const tablet: DeviceParams = {
+  id: 123,
+  manufacturer: "Apple",
+  model: "iPad 9.7 (2018)",
+  platform_id: 11,
+  id_profile: 62735,
+  os_version: "iOS 15.6.1 (15.6.1)",
+  operating_system: "iOS",
+  form_factor: "Tablet",
+};
+
+const desktop: DeviceParams = {
+  id: 1234,
+  platform_id: 8,
+  id_profile: 47337,
+  os_version: "Windows 11",
+  operating_system: "Windows",
+  form_factor: "PC",
+  pc_type: "Notebook",
+};
+
 const useCase1: UseCaseParams = {
   id: 123,
   title: "Use Case 1: Titolone (Web)",
@@ -192,6 +213,8 @@ describe("GET /campaigns/{cid}/widgets", () => {
         await bugType.addDefaultItems();
         await bugStatus.addDefaultItems();
         await devices.insert(device_1);
+        await devices.insert(tablet);
+        await devices.insert(desktop);
       } catch (error) {
         console.error(error);
         reject(error);
@@ -297,6 +320,42 @@ describe("GET /campaigns/{cid}/widgets", () => {
     expect(response.body.kind).toEqual("bugsByUseCase");
 
     expect(response.body.data[1].title).toEqual(useCase2.title);
+    expect(response.body.data[1].bugs).toEqual(1);
+  });
+
+  it("Should answer 200 and return the bugs by device widget", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_1.id}/widgets?s=bugs-by-device`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(200);
+    expect(response.body.kind).toEqual("bugsByDevice");
+    expect(response.body.data[0].bugs).toEqual(2);
+
+    console.log(response.body.data[0].bugs);
+  });
+
+  it("Should answer 200 and return the bugs by device widget (with 2 device type)", async () => {
+    //Update bug_2
+    await bugs.update(
+      [
+        {
+          dev_id: tablet.id,
+          manufacturer: tablet.manufacturer,
+          model: tablet.model,
+          os: tablet.operating_system,
+          os_version: tablet.os_version,
+        },
+      ],
+      [{ id: bug_2.id }]
+    );
+
+    const response = await request(app)
+      .get(`/campaigns/${campaign_1.id}/widgets?s=bugs-by-device`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(200);
+
+    expect(response.body.kind).toEqual("bugsByDevice");
+    expect(response.body.data[0].bugs).toEqual(1);
     expect(response.body.data[1].bugs).toEqual(1);
   });
 

--- a/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
@@ -1,0 +1,245 @@
+import app from "@src/app";
+import request from "supertest";
+import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
+import { table as platformTable } from "@src/__mocks__/database/platforms";
+import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
+import userTaskMedia from "@src/__mocks__/database/user_task_media";
+import useCases from "@src/__mocks__/database/use_cases";
+import reports from "@src/__mocks__/database/report";
+import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
+import bugMedia from "@src/__mocks__/database/bug_media";
+import bugSeverity from "@src/__mocks__/database/bug_severity";
+import bugReplicability from "@src/__mocks__/database/bug_replicability";
+import bugType from "@src/__mocks__/database/bug_type";
+import bugStatus from "@src/__mocks__/database/bug_status";
+import devices, { DeviceParams } from "@src/__mocks__/database/device";
+
+const customer_1 = {
+  id: 999,
+  company: "Company 999",
+  company_logo: "logo999.png",
+  tokens: 100,
+};
+
+const user_to_customer_1 = {
+  wp_user_id: 1,
+  customer_id: 999,
+};
+
+const project_1 = {
+  id: 999,
+  display_name: "Project 999",
+  customer_id: 999,
+};
+
+const project_2 = {
+  id: 998,
+  display_name: "Project 998",
+  customer_id: 10,
+};
+
+const user_to_project_1 = {
+  wp_user_id: 1,
+  project_id: 999,
+};
+
+const campaign_type_1 = {
+  id: 999,
+  name: "Functional Testing (Bug Hunting)",
+  type: FUNCTIONAL_CAMPAIGN_TYPE_ID,
+};
+
+const campaign_1 = {
+  id: 1,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 2 title",
+  customer_title: "Campaign 2 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: project_1.id,
+};
+
+const campaign_2 = {
+  id: 2,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 998 title",
+  customer_title: "Campaign 998 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: project_2.id,
+};
+
+const device_1: DeviceParams = {
+  id: 12,
+  manufacturer: "Apple",
+  model: "iPhone 13",
+  platform_id: 2,
+  id_profile: 61042,
+  os_version: "iOS 16 (16)",
+  operating_system: "iOS",
+  form_factor: "Smartphone",
+};
+
+const bug_1: BugsParams = {
+  id: 1,
+  internal_id: "BUG1",
+  message: "[CON-TEXT] - Bug 1 super-message",
+  description: "Bug 1 description",
+  expected_result: "Bug 1 expected result",
+  current_result: "Bug 1 current result",
+  campaign_id: campaign_1.id,
+  bug_type_id: 1,
+  bug_replicability_id: 1,
+  status_id: 1,
+  status_reason: "Bug 1 status reason",
+  application_section: "Bug 1 application section",
+  note: "Bug 1 note",
+  wp_user_id: 1,
+  dev_id: device_1.id,
+  manufacturer: device_1.manufacturer,
+  model: device_1.model,
+  os: device_1.operating_system,
+  os_version: device_1.os_version,
+  severity_id: 1,
+};
+
+const bug_2: BugsParams = {
+  id: 2,
+  internal_id: "BUG2",
+  message: "Bug 2 message",
+  description: "Bug 2 description",
+  expected_result: "Bug 2 expected result",
+  current_result: "Bug 2 current result",
+  campaign_id: campaign_1.id,
+  bug_type_id: 1,
+  bug_replicability_id: 1,
+  status_id: 1,
+  status_reason: "Bug 2 status reason",
+  application_section: "Bug 2 application section",
+  note: "Bug 2 note",
+  wp_user_id: 1,
+  is_favorite: 1,
+  dev_id: device_1.id,
+  manufacturer: device_1.manufacturer,
+  model: device_1.model,
+  os: device_1.operating_system,
+  os_version: device_1.os_version,
+  severity_id: 2,
+};
+
+const bug_media_1 = {
+  id: 123,
+  bug_id: bug_1.id,
+  location: "https://example.com/bug_media_1.png",
+  type: "image",
+  uploaded: "2021-10-19 12:57:57.0",
+};
+
+describe("GET /campaigns/{cid}/widgets", () => {
+  beforeAll(async () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await dbAdapter.create();
+        await platformTable.create();
+
+        await dbAdapter.add({
+          companies: [customer_1],
+          userToCustomers: [user_to_customer_1],
+          projects: [project_1, project_2],
+          userToProjects: [user_to_project_1],
+          campaignTypes: [campaign_type_1],
+          campaigns: [campaign_1, campaign_2],
+        });
+
+        await bugs.mock();
+        await bugMedia.mock();
+        await bugSeverity.mock();
+        await bugReplicability.mock();
+        await bugType.mock();
+        await bugStatus.mock();
+        await devices.mock();
+        await useCases.mock();
+        await userTaskMedia.mock();
+        await reports.mock();
+
+        await bugs.insert(bug_1);
+        await bugs.insert(bug_2);
+        await bugMedia.insert(bug_media_1);
+        await bugSeverity.addDefaultItems();
+        await bugReplicability.addDefaultItems();
+        await bugType.addDefaultItems();
+        await bugStatus.addDefaultItems();
+        await devices.insert(device_1);
+      } catch (error) {
+        console.error(error);
+        reject(error);
+      }
+
+      resolve(true);
+    });
+  });
+
+  afterAll(async () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await dbAdapter.drop();
+        await platformTable.drop();
+        await bugs.dropMock();
+        await bugMedia.dropMock();
+        await bugSeverity.dropMock();
+        await bugReplicability.dropMock();
+        await bugType.dropMock();
+        await bugStatus.dropMock();
+        await devices.dropMock();
+        await useCases.dropMock();
+        await userTaskMedia.dropMock();
+        await reports.dropMock();
+      } catch (error) {
+        console.error(error);
+        reject(error);
+      }
+
+      resolve(true);
+    });
+  });
+
+  // It should answer 403 if user is not logged in
+  it("Should answer 403 if user is not logged in", async () => {
+    const response = await request(app).get(
+      `/campaigns/${campaign_1.id}/widgets`
+    );
+    expect(response.status).toBe(403);
+  });
+
+  // It should answer 400 if campaign does not exist
+  it("Should answer 400 if campaign does not exist", async () => {
+    const response = await request(app)
+      .get(`/campaigns/999999/widgets`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(400);
+  });
+
+  // It should answer 403 if the user has no permissions to see the campaign
+  it("Should answer 403 if the user has no permissions to see the campaign", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_2.id}/widgets?s=bugs-by-device`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(403);
+  });
+
+  // It should answer 400 if the widget does not exist or has an invalid name
+  it("Should answer 400 if the widget does not exist or has an invalid name", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_1.id}/widgets?s=invalid`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -24,6 +24,8 @@ export default async (
   const cid = parseInt(c.request.params.cid as string);
   const widget = c.request.query.s as string;
 
+  res.status_code = 200;
+
   try {
     if (!cid || !widget) {
       throw {
@@ -56,7 +58,7 @@ export default async (
 
     // Return requested widget
     switch (widget) {
-      case "bugs-by-use-case":
+      case "bugs-by-usecase":
         return await getWidgetBugsByUseCase(campaign);
       case "bugs-by-device":
         return await getWidgetBugsByDevice(campaign);

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -1,8 +1,12 @@
 /** OPENAPI-ROUTE: get-campaigns-cid-widgets-wslug */
-import { getCampaign, getWidgetBugsByUseCase } from "@src/utils/campaigns";
+import { Context } from "openapi-backend";
+import {
+  getCampaign,
+  getWidgetBugsByDevice,
+  getWidgetBugsByUseCase,
+} from "@src/utils/campaigns";
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getProjectById } from "@src/utils/projects";
-import { Context } from "openapi-backend";
 
 export default async (
   c: Context,
@@ -18,7 +22,7 @@ export default async (
   } as StoplightComponents["schemas"]["Error"];
 
   const cid = parseInt(c.request.params.cid as string);
-  const widget = c.request.params.wslug as string;
+  const widget = c.request.query.s as string;
 
   try {
     if (!cid || !widget) {
@@ -38,8 +42,9 @@ export default async (
     if (!campaign) {
       throw {
         ...error,
-        code: 400,
-        message: "Campaign not found",
+        code: 403,
+        message:
+          "Campaign doesn't exist or you don't have permission to view it",
       };
     }
 
@@ -54,7 +59,7 @@ export default async (
       case "bugs-by-use-case":
         return await getWidgetBugsByUseCase(campaign);
       case "bugs-by-device":
-        return await getWidgetBugsByUseCase(campaign);
+        return await getWidgetBugsByDevice(campaign);
     }
 
     throw {

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -1,0 +1,72 @@
+/** OPENAPI-ROUTE: get-campaigns-cid-widgets-wslug */
+import { getCampaign, getWidgetBugsByUseCase } from "@src/utils/campaigns";
+import { ERROR_MESSAGE } from "@src/utils/constants";
+import { getProjectById } from "@src/utils/projects";
+import { Context } from "openapi-backend";
+
+export default async (
+  c: Context,
+  req: OpenapiRequest,
+  res: OpenapiResponse
+) => {
+  const user = req.user;
+
+  const error = {
+    code: 500,
+    message: ERROR_MESSAGE,
+    error: true,
+  } as StoplightComponents["schemas"]["Error"];
+
+  const cid = parseInt(c.request.params.cid as string);
+  const widget = c.request.params.wslug as string;
+
+  try {
+    if (!cid || !widget) {
+      throw {
+        ...error,
+        code: 400,
+        message: "Missing campaign id or widget slug",
+      };
+    }
+
+    // Check if the campaign exists
+    const campaign = await getCampaign({
+      campaignId: cid,
+      withOutputs: true,
+    });
+
+    if (!campaign) {
+      throw {
+        ...error,
+        code: 400,
+        message: "Campaign not found",
+      };
+    }
+
+    // Check if user has permission to access the campaign
+    await getProjectById({
+      projectId: campaign.project.id,
+      user: user,
+    });
+
+    // Return requested widget
+    switch (widget) {
+      case "bugs-by-use-case":
+        return await getWidgetBugsByUseCase(campaign);
+      case "bugs-by-device":
+        return await getWidgetBugsByUseCase(campaign);
+    }
+
+    throw {
+      ...error,
+      code: 401,
+      message: "The requested widget is not available or you don't have access",
+    };
+  } catch (e: any) {
+    res.status_code = e.code || 500;
+    error.code = e.code || 500;
+    error.message = e.message || ERROR_MESSAGE;
+
+    return error;
+  }
+};

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -567,6 +567,7 @@ export interface components {
       data: (components["schemas"]["UseCase"] & {
         /** @description Unique bugs */
         bugs: number;
+        usecase_id: number;
       })[];
       /** @enum {string} */
       kind: "bugsByUseCase";

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -853,6 +853,7 @@ export interface operations {
             | components["schemas"]["WidgetBugsByDevice"];
         };
       };
+      400: components["responses"]["Error"];
       401: components["responses"]["Error"];
       403: components["responses"]["Error"];
       500: components["responses"]["Error"];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -57,6 +57,15 @@ export interface paths {
       };
     };
   };
+  "/campaigns/{cid}/widgets": {
+    get: operations["get-campaigns-cid-widgets-wslug"];
+    parameters: {
+      path: {
+        /** Campaign id */
+        cid: number;
+      };
+    };
+  };
   "/projects": {
     post: operations["post-projects"];
   };
@@ -550,6 +559,34 @@ export interface components {
       /** @description express coins */
       coins?: number;
     };
+    /**
+     * WidgetBugsByUseCase
+     * @description Returns a list of use case with the number of bugs
+     */
+    WidgetBugsByUseCase: {
+      data: (components["schemas"]["UseCase"] & {
+        /** @description Unique bugs */
+        bugs: number;
+      })[];
+      /** @enum {string} */
+      kind: "bugsByUseCase";
+    };
+    /**
+     * WidgetBugsByDevice
+     * @description Returns a list of devices with the number of bugs
+     */
+    WidgetBugsByDevice: {
+      data: ((
+        | components["schemas"]["Smartphone"]
+        | components["schemas"]["Desktop"]
+        | components["schemas"]["Tablet"]
+      ) & {
+        /** @description Unique bugs */
+        bugs: number;
+      })[];
+      /** @enum {string} */
+      kind: "bugsByDevice";
+    };
   };
   responses: {
     /** Example response */
@@ -578,6 +615,8 @@ export interface components {
     cid: number;
     /** @description Defines an identifier for the bug object (BUG ID) */
     bid: string;
+    /** @description Campaign widget slug */
+    wslug: "bugs-by-usecase" | "bugs-by-device" | "bugs-by-type";
   };
   requestBodies: {
     Credentials: {
@@ -792,6 +831,31 @@ export interface operations {
           "application/json": components["schemas"]["Report"][];
         };
       };
+    };
+  };
+  "get-campaigns-cid-widgets-wslug": {
+    parameters: {
+      path: {
+        /** Campaign id */
+        cid: number;
+      };
+      query: {
+        /** Campaign widget slug */
+        wslug: components["parameters"]["wslug"];
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json":
+            | components["schemas"]["WidgetBugsByUseCase"]
+            | components["schemas"]["WidgetBugsByDevice"];
+        };
+      };
+      401: components["responses"]["Error"];
+      403: components["responses"]["Error"];
+      500: components["responses"]["Error"];
     };
   };
   "post-projects": {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -841,7 +841,7 @@ export interface operations {
       };
       query: {
         /** Campaign widget slug */
-        wslug: components["parameters"]["wslug"];
+        s: components["parameters"]["wslug"];
       };
     };
     responses: {

--- a/src/utils/bugs/getBugById/index.ts
+++ b/src/utils/bugs/getBugById/index.ts
@@ -66,7 +66,7 @@ export const getBugById = async (bugId: number): Promise<BugWithMedia> => {
   }
 
   // Get bug device
-  const device = await getBugDevice(bug);
+  const device = getBugDevice(bug);
 
   // Get bug media
   const media = await getBugMedia(bugId);

--- a/src/utils/bugs/getBugDevice/index.ts
+++ b/src/utils/bugs/getBugDevice/index.ts
@@ -1,13 +1,12 @@
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { BugsParams } from "@src/__mocks__/database/bugs";
 
-export const getBugDevice = async (
+export const getBugDevice = (
   bug: BugsParams & { form_factor: string; pc_type: string }
-): Promise<
+):
   | StoplightComponents["schemas"]["Smartphone"]
   | StoplightComponents["schemas"]["Tablet"]
-  | StoplightComponents["schemas"]["Desktop"]
-> => {
+  | StoplightComponents["schemas"]["Desktop"] => {
   const error = {
     code: 500,
     message: ERROR_MESSAGE,

--- a/src/utils/campaigns/createUseCases/index.ts
+++ b/src/utils/campaigns/createUseCases/index.ts
@@ -19,6 +19,9 @@ export const createUseCases = async (
     position: 0,
     allow_media: 0,
     optimize_media: 0,
+    simple_title: "",
+    info: "",
+    prefix: "",
   };
 
   const allowedFields = Object.keys(defaultUseCase);

--- a/src/utils/campaigns/getCampaignBugs/index.ts
+++ b/src/utils/campaigns/getCampaignBugs/index.ts
@@ -130,7 +130,7 @@ const formatBugs = async (bugs: any, campaignId: number) => {
 
   for (const bug of bugs) {
     // Get bug device
-    const device = await getBugDevice(bug);
+    const device = getBugDevice(bug);
 
     const bugTitle = getBugTitle({
       bugTitle: bug.title,

--- a/src/utils/campaigns/getWidgetBugsByDevice/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByDevice/index.ts
@@ -1,0 +1,19 @@
+export const getWidgetBugsByDevices = async (
+  campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
+): Promise<StoplightComponents["schemas"]["WidgetBugsByDevice"]> => {
+  const error = {
+    code: 400,
+    message: "Something went wrong with bugs-by-device widget",
+    error: true,
+  } as StoplightComponents["schemas"]["Error"];
+
+  // Widget requires bugs output
+  if (!campaign.outputs || !campaign.outputs.includes("bugs")) {
+    throw error;
+  }
+
+  throw {
+    code: 501,
+    message: "not implemented",
+  };
+};

--- a/src/utils/campaigns/getWidgetBugsByDevice/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByDevice/index.ts
@@ -1,4 +1,6 @@
-export const getWidgetBugsByDevices = async (
+import { getCampaignBugs } from "../getCampaignBugs";
+
+export const getWidgetBugsByDevice = async (
   campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
 ): Promise<StoplightComponents["schemas"]["WidgetBugsByDevice"]> => {
   const error = {
@@ -11,6 +13,13 @@ export const getWidgetBugsByDevices = async (
   if (!campaign.outputs || !campaign.outputs.includes("bugs")) {
     throw error;
   }
+
+  const bugs = await getCampaignBugs({
+    campaignId: campaign.id,
+    filterBy: {
+      is_duplicated: "0",
+    },
+  });
 
   throw {
     code: 501,

--- a/src/utils/campaigns/getWidgetBugsByDevice/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByDevice/index.ts
@@ -1,4 +1,14 @@
-import { getCampaignBugs } from "../getCampaignBugs";
+import * as db from "@src/features/db";
+import { getBugDevice } from "@src/utils/bugs/getBugDevice";
+import { BugsParams } from "@src/__mocks__/database/bugs";
+
+type device =
+  | StoplightComponents["schemas"]["Desktop"]
+  | StoplightComponents["schemas"]["Smartphone"]
+  | StoplightComponents["schemas"]["Tablet"];
+
+type deviceFromBug = device & { deviceKey: string };
+type widgetDataType = device & { bugs: number };
 
 export const getWidgetBugsByDevice = async (
   campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
@@ -14,15 +24,86 @@ export const getWidgetBugsByDevice = async (
     throw error;
   }
 
-  const bugs = await getCampaignBugs({
-    campaignId: campaign.id,
-    filterBy: {
-      is_duplicated: "0",
-    },
-  });
+  const allowedStatuses = "2, 4"; // TODO: get status ids from config
 
-  throw {
-    code: 501,
-    message: "not implemented",
-  };
+  const query = `SELECT b.id,
+  b.internal_id,
+  b.campaign_id,
+  b.message     as title,
+  b.description,
+  b.expected_result,
+  b.current_result,
+  b.status_id,
+  b.created,
+  b.updated,
+  b.note,
+  device.form_factor,
+  device.pc_type,
+  b.manufacturer,
+  b.model,
+  b.os,
+  b.os_version,
+  b.application_section,
+  b.application_section_id,
+  b.is_duplicated,
+  b.duplicated_of_id,
+  b.is_favorite,
+  b.bug_replicability_id,
+  b.bug_type_id,
+  b.severity_id
+  from wp_appq_evd_bug b
+    LEFT JOIN wp_crowd_appq_device device ON (b.dev_id = device.id)
+  WHERE b.campaign_id = ?
+    AND b.is_duplicated = 0
+    AND b.status_id IN (${allowedStatuses})`;
+
+  const bugs = await db.query(db.format(query, [campaign.id]));
+
+  if (!bugs) {
+    throw {
+      ...error,
+      code: 401,
+      message: "No bugs found for this campaign",
+    };
+  }
+
+  const devices: Array<deviceFromBug> = bugs.map(
+    (bug: BugsParams & { form_factor: string; pc_type: string }) => {
+      const device = getBugDevice(bug);
+      return {
+        ...device,
+        deviceKey: Object.values(device).join(""), // Used to group devices
+      };
+    }
+  );
+
+  // Group by device by deviceKey
+  const groupedDevices = devices.reduce(
+    (
+      acc: {
+        [key: string]: widgetDataType;
+      },
+      { deviceKey, ...device }: deviceFromBug
+    ) => {
+      const key: string = deviceKey;
+      if (!acc[key]) {
+        acc[key] = {
+          ...device,
+          bugs: 0,
+        };
+      }
+
+      acc[key].bugs += 1;
+
+      return acc;
+    },
+    {}
+  );
+
+  const data: Array<widgetDataType> = Object.values(groupedDevices);
+
+  return {
+    data: data,
+    kind: "bugsByDevice",
+  } as StoplightComponents["schemas"]["WidgetBugsByDevice"];
 };

--- a/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
@@ -1,3 +1,14 @@
+import * as db from "@src/features/db";
+
+interface bugsByUseCaseQueryResults {
+  total: number;
+  title: string;
+  content: string;
+  simple_title: string;
+  info: string;
+  prefix: string;
+}
+
 export const getWidgetBugsByUseCase = async (
   campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
 ): Promise<StoplightComponents["schemas"]["WidgetBugsByUseCase"]> => {
@@ -12,8 +23,45 @@ export const getWidgetBugsByUseCase = async (
     throw error;
   }
 
-  throw {
-    code: 501,
-    message: "not implemented",
-  };
+  const allowedStatuses = "2, 4"; // TODO: get status ids from config
+
+  const query = `SELECT
+      count(b.id) as total,
+      t.title,
+      t.content,
+      t.simple_title,
+      t.info,
+      t.prefix
+    from
+      wp_appq_evd_bug b
+      JOIN wp_appq_campaign_task t ON (t.id = b.application_section_id)
+    where
+      b.campaign_id = ?
+      AND b.is_duplicated = 0
+      AND b.status_id IN (${allowedStatuses})
+    group by
+      t.id
+    ORDER BY
+      total DESC;`;
+
+  const result = await db.query(db.format(query, [campaign.id]));
+
+  if (!result) {
+    throw {
+      ...error,
+      code: 401,
+      message: "No bugs found for this campaign",
+    };
+  }
+
+  const useCasesWithBugs = result.map((row: bugsByUseCaseQueryResults) => ({
+    title: row.simple_title.length ? row.simple_title : row.title,
+    description: row.content,
+    bugs: row.total,
+  }));
+
+  return {
+    data: useCasesWithBugs,
+    kind: "bugsByUseCase",
+  } as StoplightComponents["schemas"]["WidgetBugsByUseCase"];
 };

--- a/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
@@ -2,6 +2,7 @@ import * as db from "@src/features/db";
 
 interface bugsByUseCaseQueryResults {
   total: number;
+  id: number;
   title: string;
   content: string;
   simple_title: string;
@@ -27,6 +28,7 @@ export const getWidgetBugsByUseCase = async (
 
   const query = `SELECT
       count(b.id) as total,
+      t.id,
       t.title,
       t.content,
       t.simple_title,
@@ -34,7 +36,7 @@ export const getWidgetBugsByUseCase = async (
       t.prefix
     from
       wp_appq_evd_bug b
-      JOIN wp_appq_campaign_task t ON (t.id = b.application_section_id)
+      LEFT JOIN wp_appq_campaign_task t ON (t.id = b.application_section_id)
     where
       b.campaign_id = ?
       AND b.is_duplicated = 0
@@ -55,8 +57,12 @@ export const getWidgetBugsByUseCase = async (
   }
 
   const useCasesWithBugs = result.map((row: bugsByUseCaseQueryResults) => ({
-    title: row.simple_title.length ? row.simple_title : row.title,
-    description: row.content,
+    usecase_id: row.id ?? -1,
+    title:
+      row.simple_title && row.simple_title.length
+        ? row.simple_title
+        : row.title || "Not a specific use case",
+    description: row.content ?? "",
     bugs: row.total,
   }));
 

--- a/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
@@ -1,0 +1,19 @@
+export const getWidgetBugsByUseCase = async (
+  campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
+): Promise<StoplightComponents["schemas"]["WidgetBugsByDevice"]> => {
+  const error = {
+    code: 400,
+    message: "Something went wrong with bugs-by-use-case widget",
+    error: true,
+  } as StoplightComponents["schemas"]["Error"];
+
+  // Widget requires bugs output
+  if (!campaign.outputs || !campaign.outputs.includes("bugs")) {
+    throw error;
+  }
+
+  throw {
+    code: 501,
+    message: "not implemented",
+  };
+};

--- a/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
+++ b/src/utils/campaigns/getWidgetBugsByUseCase/index.ts
@@ -1,6 +1,6 @@
 export const getWidgetBugsByUseCase = async (
   campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
-): Promise<StoplightComponents["schemas"]["WidgetBugsByDevice"]> => {
+): Promise<StoplightComponents["schemas"]["WidgetBugsByUseCase"]> => {
   const error = {
     code: 400,
     message: "Something went wrong with bugs-by-use-case widget",

--- a/src/utils/campaigns/index.ts
+++ b/src/utils/campaigns/index.ts
@@ -11,7 +11,7 @@ import { getCampaignFamily } from "./getCampaignFamily";
 import { getCampaignOutputs } from "./getCampaignOutputs";
 import { getCampaignBugs } from "./getCampaignBugs";
 import { getTitleRule, getBugTitle } from "./getTitleRule";
-import { getWidgetBugsByDevices } from "./getWidgetBugsByDevice";
+import { getWidgetBugsByDevice } from "./getWidgetBugsByDevice";
 import { getWidgetBugsByUseCase } from "./getWidgetBugsByUseCase";
 
 export {
@@ -29,6 +29,6 @@ export {
   getCampaignBugs,
   getTitleRule,
   getBugTitle,
-  getWidgetBugsByDevices,
+  getWidgetBugsByDevice,
   getWidgetBugsByUseCase,
 };

--- a/src/utils/campaigns/index.ts
+++ b/src/utils/campaigns/index.ts
@@ -11,6 +11,8 @@ import { getCampaignFamily } from "./getCampaignFamily";
 import { getCampaignOutputs } from "./getCampaignOutputs";
 import { getCampaignBugs } from "./getCampaignBugs";
 import { getTitleRule, getBugTitle } from "./getTitleRule";
+import { getWidgetBugsByDevices } from "./getWidgetBugsByDevice";
+import { getWidgetBugsByUseCase } from "./getWidgetBugsByUseCase";
 
 export {
   checkCampaignRequest,
@@ -27,4 +29,6 @@ export {
   getCampaignBugs,
   getTitleRule,
   getBugTitle,
+  getWidgetBugsByDevices,
+  getWidgetBugsByUseCase,
 };


### PR DESCRIPTION
### add getBugsByUseCae
- use case with total number of bugs
- include bugs without usecase (grouped under "not a specific usecase")
- order by total number of bugs

### add getBugsByDevice
- device with total number of bugs
- support only smartphone, tablet e desktop. Unknown devices must be recognized as desktop
- order by total number of bugs