### PR TITLE
Un 83 campaign progress api

### DIFF
--- a/src/__mocks__/database/cp_has_candidate.ts
+++ b/src/__mocks__/database/cp_has_candidate.ts
@@ -1,0 +1,48 @@
+import Table from "./tryber_table";
+
+type CandidateParams = {
+  user_id?: number;
+  campaign_id?: number;
+  subscription_date?: string;
+  accepted?: number;
+  devices?: string;
+  selected_device?: number;
+  results?: number;
+  modified?: string;
+  group_id?: number;
+};
+
+const defaultItem: CandidateParams = {
+  user_id: 1,
+  campaign_id: 1,
+  subscription_date: new Date("01/01/2021").toISOString(),
+  accepted: 0,
+  devices: "",
+  selected_device: 0,
+  results: 0,
+  modified: new Date("01/01/2021").toISOString(),
+  group_id: 1,
+};
+
+class Candidates extends Table<CandidateParams> {
+  protected name = "wp_crowd_appq_has_candidate";
+  protected columns = [
+    "user_id INTEGER(11) NOT NULL PRIMARY KEY",
+    "campaign_id INTEGER(11)",
+    "subscription_date DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP",
+    "accepted INTEGER(1)",
+    "devices VARCHAR(600) NOT NULL DEFAULT 0",
+    "selected_device INTEGER(100) NOT NULL DEFAULT 0",
+    "results INTEGER(11) NOT NULL DEFAULT 0",
+    "modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP",
+    "group_id INTEGER(1) NOT NULL DEFAULT 1",
+  ];
+
+  constructor() {
+    super(defaultItem);
+  }
+}
+
+const candidates = new Candidates();
+export default candidates;
+export type { CandidateParams };

--- a/src/__mocks__/database/user_task.ts
+++ b/src/__mocks__/database/user_task.ts
@@ -1,0 +1,31 @@
+import Table from "./tryber_table";
+
+type UserTaskParams = {
+  id?: number;
+  task_id?: number;
+  tester_id?: number;
+  is_completed?: number;
+  creation_date?: string;
+};
+
+const defaultItem: UserTaskParams = {
+  is_completed: 1,
+};
+
+class UserTask extends Table<UserTaskParams> {
+  protected name = "wp_appq_user_task";
+  protected columns = [
+    "id INTEGER PRIMARY KEY AUTOINCREMENT",
+    "tester_id INTEGER NOT NULL",
+    "task_id INTEGER NOT NULL",
+    "is_completed INTEGER NOT NULL",
+    "creation_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP",
+  ];
+  constructor() {
+    super(defaultItem);
+  }
+}
+
+const userTask = new UserTask();
+export default userTask;
+export type { UserTaskParams };

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -303,7 +303,7 @@ paths:
           type: number
         description: Campaign id
     get:
-      summary: Get Campaign widget data
+      summary: Get Campaign meta info
       tags: []
       responses:
         '200':
@@ -322,6 +322,9 @@ paths:
                         description: Array of form factors
                         items:
                           type: string
+                    required:
+                      - selected_testers
+                      - allowed_devices
               examples: {}
         '400':
           $ref: '#/components/responses/Error'

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -325,7 +325,35 @@ paths:
                     required:
                       - selected_testers
                       - allowed_devices
-              examples: {}
+              examples:
+                Example 1:
+                  value:
+                    id: 0
+                    start_date: string
+                    end_date: string
+                    close_date: string
+                    title: string
+                    customer_title: string
+                    is_public: 0
+                    bug_form: -1
+                    type:
+                      id: 0
+                      name: string
+                    family:
+                      id: 0
+                      name: string
+                    status:
+                      id: 0
+                      name: string
+                    project:
+                      id: 0
+                      name: string
+                    description: string
+                    base_bug_internal_id: string
+                    selected_testers: 16
+                    allowed_devices:
+                      - smartphone
+                      - tablet
         '400':
           $ref: '#/components/responses/Error'
         '401':

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -276,7 +276,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
+                anyOf:
                   - $ref: '#/components/schemas/WidgetBugsByUseCase'
                   - $ref: '#/components/schemas/WidgetBugsByDevice'
                   - $ref: '#/components/schemas/WidgetCampaignProgress'
@@ -1825,6 +1825,8 @@ components:
           type: string
           enum:
             - bugsByUseCase
+          default: bugsByUseCase
+          example: bugsByUseCase
       required:
         - data
         - kind
@@ -1869,6 +1871,8 @@ components:
           type: string
           enum:
             - bugsByDevice
+          example: bugsByDevice
+          default: bugsByDevice
       required:
         - data
         - kind
@@ -1881,23 +1885,17 @@ components:
       x-examples:
         Example 1:
           data:
-            start_date: string
-            end_date: string
-            usecase_completion: 12.5
-            time_elapsed: 0
-            expected_duration: 0
+            - start_date: string
+              end_date: string
+              usecase_completion: 12.5
+              time_elapsed: 0
+              expected_duration: 0
           kind: campaignProgress
       properties:
         data:
           type: array
           items:
             type: object
-            required:
-            - start_date
-            - end_date
-            - usecase_completion
-            - time_elapsed
-            - expected_duration
             properties:
               start_date:
                 type: string
@@ -1921,10 +1919,18 @@ components:
               expected_duration:
                 type: integer
                 description: Expected amount of hours required to complete the campaign
+            required:
+              - start_date
+              - end_date
+              - usecase_completion
+              - time_elapsed
+              - expected_duration
         kind:
           type: string
           enum:
             - campaignProgress
+          default: campaignProgress
+          example: campaignProgress
       required:
         - data
         - kind

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -1878,38 +1878,49 @@ components:
         id: 5b2de85594c7e
       type: object
       description: Used to show an overview about a specific campaign.
+      x-examples:
+        Example 1:
+          data:
+            start_date: string
+            end_date: string
+            usecase_completion: 12.5
+            time_elapsed: 0
+            expected_duration: 0
+          kind: campaignProgress
       properties:
         data:
-          type: object
-          required:
+          type: array
+          items:
+            type: object
+            required:
             - start_date
             - end_date
             - usecase_completion
             - time_elapsed
             - expected_duration
-          properties:
-            start_date:
-              type: string
-            end_date:
-              type: string
-            usecase_completion:
-              type: number
-              minimum: 0
-              maximum: 100
-              format: float
-              enum:
-                - 12.5
-                - 37.5
-                - 62.5
-                - 87.5
-                - 100
-              description: Percentage fixed rate of completion
-            time_elapsed:
-              type: integer
-              description: Number of hours from start_date
-            expected_duration:
-              type: integer
-              description: Expected amount of hours required to complete the campaign
+            properties:
+              start_date:
+                type: string
+              end_date:
+                type: string
+              usecase_completion:
+                type: number
+                minimum: 0
+                maximum: 100
+                format: float
+                enum:
+                  - 12.5
+                  - 37.5
+                  - 62.5
+                  - 87.5
+                  - 100
+                description: Percentage fixed rate of completion
+              time_elapsed:
+                type: integer
+                description: Number of hours from start_date
+              expected_duration:
+                type: integer
+                description: Expected amount of hours required to complete the campaign
         kind:
           type: string
           enum:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -289,30 +289,28 @@ paths:
                         bugs: 10
                         usecase_id: 1220
                     kind: bugsByUseCase
-                Bugs by Device:
+                Example 2:
                   value:
                     data:
-                      - manufacturer: Samsung
-                        model: Galaxy S22 Ultra
-                        os: Android
-                        os_version: '13'
-                        type: smartphone
-                        bugs: 12
-                      - desktop_type: Gaming PC
-                        os: Windows
-                        os_version: Windows 10 May 2021 Update (19043)
-                        type: desktop
-                        bugs: 4
-                    kind: bugsByDevice
-                Campaign Progress:
-                  value:
-                    data:
-                      - start_date: string
-                        end_date: string
-                        usecase_completion: 12.5
-                        time_elapsed: 0
-                        expected_duration: 0
-                    kind: campaignProgress
+                      - title: string
+                        description: string
+                        functionality:
+                          id: 0
+                          title: string
+                          description: string
+                          content: string
+                          category:
+                            id: 0
+                            name: string
+                          device_type: webapp
+                          locale: en
+                          image: 'http://example.com'
+                          requiresLogin: false
+                        logged: true
+                        link: string
+                        bugs: 0
+                        usecase_id: 0
+                    kind: bugsByUseCase
         '400':
           $ref: '#/components/responses/Error'
         '401':
@@ -1879,7 +1877,7 @@ components:
               os_version: Windows 10 May 2021 Update (19043)
               type: desktop
               bugs: 4
-          kind: bugsByUseCase
+          kind: bugsByDevice
       description: Returns a list of devices with the number of bugs
       properties:
         data:
@@ -1915,46 +1913,44 @@ components:
       x-examples:
         Example 1:
           data:
-            - start_date: string
-              end_date: string
-              usecase_completion: 12.5
-              time_elapsed: 0
-              expected_duration: 0
+            start_date: string
+            end_date: string
+            usecase_completion: 12.5
+            time_elapsed: 0
+            expected_duration: 0
           kind: campaignProgress
       properties:
         data:
-          type: array
-          items:
-            type: object
-            properties:
-              start_date:
-                type: string
-              end_date:
-                type: string
-              usecase_completion:
-                type: number
-                minimum: 0
-                maximum: 100
-                format: float
-                enum:
-                  - 12.5
-                  - 37.5
-                  - 62.5
-                  - 87.5
-                  - 100
-                description: Percentage fixed rate of completion
-              time_elapsed:
-                type: integer
-                description: Number of hours from start_date
-              expected_duration:
-                type: integer
-                description: Expected amount of hours required to complete the campaign
-            required:
-              - start_date
-              - end_date
-              - usecase_completion
-              - time_elapsed
-              - expected_duration
+          type: object
+          properties:
+            start_date:
+              type: string
+            end_date:
+              type: string
+            usecase_completion:
+              type: number
+              minimum: 0
+              maximum: 100
+              format: float
+              enum:
+                - 12.5
+                 - 37.5
+                - 62.5
+                - 87.5
+                - 100
+              description: Percentage fixed rate of completion
+            time_elapsed:
+              type: integer
+              description: Number of hours from start_date
+            expected_duration:
+              type: integer
+              description: Expected amount of hours required to complete the campaign
+              required:
+                - start_date
+                - end_date
+                - usecase_completion
+                - time_elapsed
+                - expected_duration
         kind:
           type: string
           enum:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -279,6 +279,7 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/WidgetBugsByUseCase'
                   - $ref: '#/components/schemas/WidgetBugsByDevice'
+                  - $ref: '#/components/schemas/WidgetCampaignProgress'
               examples: {}
         '400':
           $ref: '#/components/responses/Error'
@@ -1840,20 +1841,51 @@ components:
       required:
         - data
         - kind
-    CampaignProgress:
-      title: CampaignProgress
+    WidgetCampaignProgress:
+      title: WidgetCampaignProgress
       x-stoplight:
-        id: rvnxywx76xpr3
+        id: 5b2de85594c7e
       type: object
+      description: Used to show an overview about a specific campaign.
       properties:
-        start_date:
+        data:
+          type: object
+          required:
+            - start_date
+            - end_date
+            - usecase_completion
+            - time_elapsed
+            - expected_duration
+          properties:
+            start_date:
+              type: string
+            end_date:
+              type: string
+            usecase_completion:
+              type: number
+              minimum: 0
+              maximum: 100
+              format: float
+              enum:
+                - 12.5
+                - 37.5
+                - 62.5
+                - 87.5
+                - 100
+              description: Percentage fixed rate of completion
+            time_elapsed:
+              type: integer
+              description: Number of hours from start_date
+            expected_duration:
+              type: integer
+              description: Expected amount of hours required to complete the campaign
+        kind:
           type: string
-        end_date:
-          type: string
-        duration:
-          type: string
-        time_elapsed:
-          type: string
+          enum:
+            - campaignProgress
+      required:
+        - data
+        - kind
   securitySchemes:
     JWT:
       type: http
@@ -1939,6 +1971,7 @@ components:
           - bugs-by-usecase
           - bugs-by-device
           - bugs-by-type
+          - cp-progress
       description: Campaign widget slug
   requestBodies:
     Credentials:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -1860,8 +1860,6 @@ components:
         - kind
     WidgetBugsByDevice:
       title: WidgetBugsByDevice
-      x-stoplight:
-        id: tm59wsbormo47
       type: object
       x-examples:
         Example 1:
@@ -1906,8 +1904,6 @@ components:
         - kind
     WidgetCampaignProgress:
       title: WidgetCampaignProgress
-      x-stoplight:
-        id: 5b2de85594c7e
       type: object
       description: Used to show an overview about a specific campaign.
       x-examples:
@@ -1922,6 +1918,12 @@ components:
       properties:
         data:
           type: object
+          required:
+            - start_date
+            - end_date
+            - usecase_completion
+            - time_elapsed
+            - expected_duration
           properties:
             start_date:
               type: string
@@ -1934,7 +1936,7 @@ components:
               format: float
               enum:
                 - 12.5
-                 - 37.5
+                - 37.5
                 - 62.5
                 - 87.5
                 - 100
@@ -1945,12 +1947,6 @@ components:
             expected_duration:
               type: integer
               description: Expected amount of hours required to complete the campaign
-              required:
-                - start_date
-                - end_date
-                - usecase_completion
-                - time_elapsed
-                - expected_duration
         kind:
           type: string
           enum:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -276,11 +276,43 @@ paths:
           content:
             application/json:
               schema:
-                anyOf:
+                oneOf:
                   - $ref: '#/components/schemas/WidgetBugsByUseCase'
                   - $ref: '#/components/schemas/WidgetBugsByDevice'
                   - $ref: '#/components/schemas/WidgetCampaignProgress'
-              examples: {}
+              examples:
+                Bugs by UseCase:
+                  value:
+                    data:
+                      - title: UC1 asd
+                        description: string
+                        bugs: 10
+                        usecase_id: 1220
+                    kind: bugsByUseCase
+                Bugs by Device:
+                  value:
+                    data:
+                      - manufacturer: Samsung
+                        model: Galaxy S22 Ultra
+                        os: Android
+                        os_version: '13'
+                        type: smartphone
+                        bugs: 12
+                      - desktop_type: Gaming PC
+                        os: Windows
+                        os_version: Windows 10 May 2021 Update (19043)
+                        type: desktop
+                        bugs: 4
+                    kind: bugsByDevice
+                Campaign Progress:
+                  value:
+                    data:
+                      - start_date: string
+                        end_date: string
+                        usecase_completion: 12.5
+                        time_elapsed: 0
+                        expected_duration: 0
+                    kind: campaignProgress
         '400':
           $ref: '#/components/responses/Error'
         '401':
@@ -1785,8 +1817,6 @@ components:
         - workspace
     WidgetBugsByUseCase:
       title: WidgetBugsByUseCase
-      x-stoplight:
-        id: tm59wsbormo47
       type: object
       x-examples:
         Example 1:

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -293,6 +293,48 @@ paths:
         - JWT: []
       parameters:
         - $ref: '#/components/parameters/wslug'
+  '/campaigns/{cid}/meta':
+    parameters:
+      - name: cid
+        in: path
+        required: true
+        schema:
+          type: number
+        description: Campaign id
+    get:
+      summary: Get Campaign widget data
+      tags: []
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Campaign'
+                  - type: object
+                    properties:
+                      selected_testers:
+                        type: number
+                      allowed_devices:
+                        type: array
+                        description: Array of form factors
+                        items:
+                          type: string
+              examples: {}
+        '400':
+          $ref: '#/components/responses/Error'
+        '401':
+          $ref: '#/components/responses/Error'
+        '403':
+          $ref: '#/components/responses/Error'
+        '500':
+          $ref: '#/components/responses/Error'
+      operationId: get-campaigns-cid-meta
+      security:
+        - JWT: []
+      parameters: []
+      description: Used to extra info about a selected campaign
   /projects:
     post:
       summary: Create a new project
@@ -1798,6 +1840,20 @@ components:
       required:
         - data
         - kind
+    CampaignProgress:
+      title: CampaignProgress
+      x-stoplight:
+        id: rvnxywx76xpr3
+      type: object
+      properties:
+        start_date:
+          type: string
+        end_date:
+          type: string
+        duration:
+          type: string
+        time_elapsed:
+          type: string
   securitySchemes:
     JWT:
       type: http

--- a/src/routes/campaigns/campaignId/meta/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/meta/_get/index.spec.ts
@@ -1,0 +1,216 @@
+import app from "@src/app";
+import request from "supertest";
+import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
+import { table as platformTable } from "@src/__mocks__/database/platforms";
+import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
+import userTaskMedia from "@src/__mocks__/database/user_task_media";
+import useCases, { UseCaseParams } from "@src/__mocks__/database/use_cases";
+import reports from "@src/__mocks__/database/report";
+import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
+import bugMedia from "@src/__mocks__/database/bug_media";
+import bugSeverity from "@src/__mocks__/database/bug_severity";
+import bugReplicability from "@src/__mocks__/database/bug_replicability";
+import bugType from "@src/__mocks__/database/bug_type";
+import bugStatus from "@src/__mocks__/database/bug_status";
+import devices, { DeviceParams } from "@src/__mocks__/database/device";
+import candidates from "@src/__mocks__/database/cp_has_candidate";
+
+const customer_1 = {
+  id: 999,
+  company: "Company 999",
+  company_logo: "logo999.png",
+  tokens: 100,
+};
+
+const user_to_customer_1 = {
+  wp_user_id: 1,
+  customer_id: 999,
+};
+
+const project_1 = {
+  id: 999,
+  display_name: "Project 999",
+  customer_id: 999,
+};
+
+const project_2 = {
+  id: 998,
+  display_name: "Project 998",
+  customer_id: 10,
+};
+
+const user_to_project_1 = {
+  wp_user_id: 1,
+  project_id: 999,
+};
+
+const campaign_type_1 = {
+  id: 999,
+  name: "Functional Testing (Bug Hunting)",
+  type: FUNCTIONAL_CAMPAIGN_TYPE_ID,
+};
+
+const campaign_1 = {
+  id: 1,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 2 title",
+  customer_title: "Campaign 2 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: project_1.id,
+  form_factor: " ",
+};
+
+const campaign_2 = {
+  id: 2,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 998 title",
+  customer_title: "Campaign 998 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: project_2.id,
+  form_factor: "1,2",
+};
+
+const useCase1: UseCaseParams = {
+  id: 123,
+  title: "Use Case 1: Titolone (Web)",
+  content: "Use Case 1 description",
+  campaign_id: campaign_1.id,
+  simple_title: "Titolone",
+  prefix: "Use Case 1:",
+  info: "Web",
+};
+
+describe("GET /campaigns/{cid}/meta", () => {
+  beforeAll(async () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await dbAdapter.create();
+        await platformTable.create();
+
+        await dbAdapter.add({
+          companies: [customer_1],
+          userToCustomers: [user_to_customer_1],
+          projects: [project_1, project_2],
+          userToProjects: [user_to_project_1],
+          campaignTypes: [campaign_type_1],
+          campaigns: [campaign_1, campaign_2],
+        });
+
+        await candidates.mock();
+        await useCases.mock();
+        await candidates.insert({
+          user_id: 32,
+          campaign_id: campaign_1.id,
+          accepted: 1,
+        });
+        await candidates.insert({
+          user_id: 33,
+          campaign_id: campaign_1.id,
+          accepted: 1,
+        });
+        await candidates.insert({
+          user_id: 34,
+          campaign_id: campaign_1.id,
+          accepted: 1,
+        });
+
+        await useCases.insert(useCase1);
+      } catch (error) {
+        console.error(error);
+        reject(error);
+      }
+
+      resolve(true);
+    });
+  });
+
+  afterAll(async () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await dbAdapter.drop();
+        await candidates.dropMock();
+        await useCases.dropMock();
+      } catch (error) {
+        console.error(error);
+        reject(error);
+      }
+
+      resolve(true);
+    });
+  });
+
+  // It should answer 403 if user is not logged in
+  it("Should answer 403 if user is not logged in", async () => {
+    const response = await request(app).get(`/campaigns/${campaign_1.id}/meta`);
+    expect(response.status).toBe(403);
+  });
+
+  // It should answer 400 if campaign does not exist
+  it("Should answer 400 if campaign does not exist", async () => {
+    const response = await request(app)
+      .get(`/campaigns/999999/meta`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(403);
+  });
+
+  // It should answer 403 if the user has no permissions to see the campaign
+  it("Should answer 403 if the user has no permissions to see the campaign", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_2.id}/meta`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(403);
+  });
+
+  it("Should answer 200 and return the number of selected testers", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_1.id}/meta`)
+      .set("Authorization", "Bearer customer");
+    expect(response.status).toBe(200);
+
+    expect(response.body.selected_testers).toEqual(3);
+    expect(response.body.allowed_devices.length).toEqual(1);
+  });
+
+  it("Should return an empty array if there are no device configurations", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_1.id}/meta`)
+      .set("Authorization", "Bearer customer");
+
+    expect(response.body.allowed_devices.length).toEqual(0);
+  });
+
+  it("Should return 0 if there are no selected testers", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_2.id}/meta`)
+      .set("Authorization", "Bearer administrator");
+
+    console.log(response.body);
+
+    expect(response.body.selected_testers).toEqual(0);
+  });
+
+  it("Should return an array with form factor", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_2.id}/meta`)
+      .set("Authorization", "Bearer administrator");
+
+    console.log(response.body);
+
+    expect(response.body.allowed_devices.length).toEqual(2);
+    expect(response.body.allowed_devices).toEqual(
+      expect.arrayContaining(["tablet", "desktop"])
+    );
+  });
+
+  // --- end of tests ---
+});

--- a/src/routes/campaigns/campaignId/meta/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/meta/_get/index.spec.ts
@@ -3,16 +3,7 @@ import request from "supertest";
 import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
 import { table as platformTable } from "@src/__mocks__/database/platforms";
 import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
-import userTaskMedia from "@src/__mocks__/database/user_task_media";
 import useCases, { UseCaseParams } from "@src/__mocks__/database/use_cases";
-import reports from "@src/__mocks__/database/report";
-import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
-import bugMedia from "@src/__mocks__/database/bug_media";
-import bugSeverity from "@src/__mocks__/database/bug_severity";
-import bugReplicability from "@src/__mocks__/database/bug_replicability";
-import bugType from "@src/__mocks__/database/bug_type";
-import bugStatus from "@src/__mocks__/database/bug_status";
-import devices, { DeviceParams } from "@src/__mocks__/database/device";
 import candidates from "@src/__mocks__/database/cp_has_candidate";
 
 const customer_1 = {
@@ -123,6 +114,11 @@ describe("GET /campaigns/{cid}/meta", () => {
           campaign_id: campaign_1.id,
           accepted: 1,
         });
+        await candidates.insert({
+          user_id: 35,
+          campaign_id: campaign_1.id,
+          accepted: 0,
+        });
 
         await useCases.insert(useCase1);
       } catch (error) {
@@ -178,7 +174,6 @@ describe("GET /campaigns/{cid}/meta", () => {
     expect(response.status).toBe(200);
 
     expect(response.body.selected_testers).toEqual(3);
-    expect(response.body.allowed_devices.length).toEqual(1);
   });
 
   it("Should return an empty array if there are no device configurations", async () => {

--- a/src/routes/campaigns/campaignId/meta/_get/index.ts
+++ b/src/routes/campaigns/campaignId/meta/_get/index.ts
@@ -1,13 +1,13 @@
-/** OPENAPI-ROUTE: get-campaigns-cid-widgets-wslug */
+/** OPENAPI-ROUTE: get-campaigns-cid-meta */
 import { Context } from "openapi-backend";
 import {
   getCampaign,
+  getCampaignMeta,
   getWidgetBugsByDevice,
   getWidgetBugsByUseCase,
 } from "@src/utils/campaigns";
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getProjectById } from "@src/utils/projects";
-import { getCampaignMeta } from "@src/utils/campaigns/getCampaignMeta";
 
 export default async (
   c: Context,
@@ -23,16 +23,15 @@ export default async (
   } as StoplightComponents["schemas"]["Error"];
 
   const cid = parseInt(c.request.params.cid as string);
-  const widget = c.request.query.s as string;
 
   res.status_code = 200;
 
   try {
-    if (!cid || !widget) {
+    if (!cid) {
       throw {
         ...error,
         code: 400,
-        message: "Missing campaign id or widget slug",
+        message: "Missing campaign id",
       };
     }
 
@@ -56,10 +55,12 @@ export default async (
       user: user,
     });
 
-    // Return requested widget
     const meta = await getCampaignMeta(campaign);
 
-    return meta;
+    return {
+      ...campaign,
+      ...meta,
+    };
   } catch (e: any) {
     res.status_code = e.code || 500;
     error.code = e.code || 500;

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -8,7 +8,6 @@ import {
 } from "@src/utils/campaigns";
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getProjectById } from "@src/utils/projects";
-import { getCampaignMeta } from "@src/utils/campaigns/getCampaignMeta";
 
 export default async (
   c: Context,
@@ -40,6 +39,7 @@ export default async (
     // Check if the campaign exists
     const campaign = await getCampaign({
       campaignId: cid,
+      withOutputs: true,
     });
 
     if (!campaign) {

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -57,9 +57,18 @@ export default async (
     });
 
     // Return requested widget
-    const meta = await getCampaignMeta(campaign);
+    switch (widget) {
+      case "bugs-by-usecase":
+        return await getWidgetBugsByUseCase(campaign);
+      case "bugs-by-device":
+        return await getWidgetBugsByDevice(campaign);
+    }
 
-    return meta;
+    throw {
+      ...error,
+      code: 401,
+      message: "The requested widget is not available or you don't have access",
+    };
   } catch (e: any) {
     res.status_code = e.code || 500;
     error.code = e.code || 500;

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -4,6 +4,7 @@ import {
   getCampaign,
   getWidgetBugsByDevice,
   getWidgetBugsByUseCase,
+  getWidgetCampaignProgress,
 } from "@src/utils/campaigns";
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getProjectById } from "@src/utils/projects";
@@ -62,6 +63,8 @@ export default async (
         return await getWidgetBugsByUseCase(campaign);
       case "bugs-by-device":
         return await getWidgetBugsByDevice(campaign);
+      case "cp-progress":
+        return await getWidgetCampaignProgress(campaign);
     }
 
     throw {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -579,7 +579,11 @@ export interface components {
         bugs: number;
         usecase_id: number;
       })[];
-      /** @enum {string} */
+      /**
+       * @default bugsByUseCase
+       * @example bugsByUseCase
+       * @enum {string}
+       */
       kind: "bugsByUseCase";
     };
     /**
@@ -595,7 +599,11 @@ export interface components {
         /** @description Unique bugs */
         bugs: number;
       })[];
-      /** @enum {string} */
+      /**
+       * @default bugsByDevice
+       * @example bugsByDevice
+       * @enum {string}
+       */
       kind: "bugsByDevice";
     };
     /**
@@ -616,8 +624,12 @@ export interface components {
         time_elapsed: number;
         /** @description Expected amount of hours required to complete the campaign */
         expected_duration: number;
-      };
-      /** @enum {string} */
+      }[];
+      /**
+       * @default campaignProgress
+       * @example campaignProgress
+       * @enum {string}
+       */
       kind: "campaignProgress";
     };
   };
@@ -885,10 +897,11 @@ export interface operations {
       /** OK */
       200: {
         content: {
-          "application/json":
-            | components["schemas"]["WidgetBugsByUseCase"]
-            | components["schemas"]["WidgetBugsByDevice"]
-            | components["schemas"]["WidgetCampaignProgress"];
+          "application/json": Partial<
+            components["schemas"]["WidgetBugsByUseCase"]
+          > &
+            Partial<components["schemas"]["WidgetBugsByDevice"]> &
+            Partial<components["schemas"]["WidgetCampaignProgress"]>;
         };
       };
       400: components["responses"]["Error"];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -66,6 +66,16 @@ export interface paths {
       };
     };
   };
+  "/campaigns/{cid}/meta": {
+    /** Used to extra info about a selected campaign */
+    get: operations["get-campaigns-cid-meta"];
+    parameters: {
+      path: {
+        /** Campaign id */
+        cid: number;
+      };
+    };
+  };
   "/projects": {
     post: operations["post-projects"];
   };
@@ -588,6 +598,28 @@ export interface components {
       /** @enum {string} */
       kind: "bugsByDevice";
     };
+    /**
+     * WidgetCampaignProgress
+     * @description Used to show an overview about a specific campaign.
+     */
+    WidgetCampaignProgress: {
+      data: {
+        start_date: string;
+        end_date: string;
+        /**
+         * Format: float
+         * @description Percentage fixed rate of completion
+         * @enum {number}
+         */
+        usecase_completion: 12.5 | 37.5 | 62.5 | 87.5 | 100;
+        /** @description Number of hours from start_date */
+        time_elapsed: number;
+        /** @description Expected amount of hours required to complete the campaign */
+        expected_duration: number;
+      };
+      /** @enum {string} */
+      kind: "campaignProgress";
+    };
   };
   responses: {
     /** Example response */
@@ -617,7 +649,11 @@ export interface components {
     /** @description Defines an identifier for the bug object (BUG ID) */
     bid: string;
     /** @description Campaign widget slug */
-    wslug: "bugs-by-usecase" | "bugs-by-device" | "bugs-by-type";
+    wslug:
+      | "bugs-by-usecase"
+      | "bugs-by-device"
+      | "bugs-by-type"
+      | "cp-progress";
   };
   requestBodies: {
     Credentials: {
@@ -851,7 +887,33 @@ export interface operations {
         content: {
           "application/json":
             | components["schemas"]["WidgetBugsByUseCase"]
-            | components["schemas"]["WidgetBugsByDevice"];
+            | components["schemas"]["WidgetBugsByDevice"]
+            | components["schemas"]["WidgetCampaignProgress"];
+        };
+      };
+      400: components["responses"]["Error"];
+      401: components["responses"]["Error"];
+      403: components["responses"]["Error"];
+      500: components["responses"]["Error"];
+    };
+  };
+  /** Used to extra info about a selected campaign */
+  "get-campaigns-cid-meta": {
+    parameters: {
+      path: {
+        /** Campaign id */
+        cid: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Campaign"] & {
+            selected_testers: number;
+            /** @description Array of form factors */
+            allowed_devices: string[];
+          };
         };
       };
       400: components["responses"]["Error"];

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -624,7 +624,7 @@ export interface components {
         time_elapsed: number;
         /** @description Expected amount of hours required to complete the campaign */
         expected_duration: number;
-      }[];
+      };
       /**
        * @default campaignProgress
        * @example campaignProgress
@@ -897,11 +897,10 @@ export interface operations {
       /** OK */
       200: {
         content: {
-          "application/json": Partial<
-            components["schemas"]["WidgetBugsByUseCase"]
-          > &
-            Partial<components["schemas"]["WidgetBugsByDevice"]> &
-            Partial<components["schemas"]["WidgetCampaignProgress"]>;
+          "application/json":
+            | components["schemas"]["WidgetBugsByUseCase"]
+            | components["schemas"]["WidgetBugsByDevice"]
+            | components["schemas"]["WidgetCampaignProgress"];
         };
       };
       400: components["responses"]["Error"];

--- a/src/utils/campaigns/getCampaign/index.ts
+++ b/src/utils/campaigns/getCampaign/index.ts
@@ -10,7 +10,10 @@ export const getCampaign = async ({
   campaignId: number;
   withOutputs?: boolean;
 }): Promise<
-  | (StoplightComponents["schemas"]["Campaign"] & { showNeedReview: boolean })
+  | (StoplightComponents["schemas"]["Campaign"] & {
+      showNeedReview: boolean;
+      formFactors: string;
+    })
   | false
 > => {
   const result = await db.query(
@@ -28,6 +31,7 @@ export const getCampaign = async ({
       c.is_public,
       c.campaign_type_id,
       c.project_id,
+      c.form_factor as formFactors,
       c.customer_id,
       c.cust_bug_vis as showNeedReview,
       c.campaign_type AS bug_form,
@@ -95,5 +99,6 @@ export const getCampaign = async ({
     }),
     showNeedReview: campaign.showNeedReview === 1 ? true : false,
     ...(withOutputs && { outputs: outputs }),
+    formFactors: campaign.formFactors || "0",
   };
 };

--- a/src/utils/campaigns/getCampaignMeta/index.ts
+++ b/src/utils/campaigns/getCampaignMeta/index.ts
@@ -1,0 +1,59 @@
+import * as db from "@src/features/db";
+import {
+  DT_DESKTOP,
+  DT_SMARTPHONE,
+  DT_SMARTWATCH,
+  DT_TABLET,
+  DT_TV,
+} from "@src/utils/constants";
+import { formatCount } from "@src/utils/paginations";
+
+interface CampaignMeta {
+  selected_testers: number;
+  allowed_devices: string[];
+}
+
+export const getCampaignMeta = async (
+  campaign: StoplightComponents["schemas"]["Campaign"] & {
+    showNeedReview: boolean;
+    formFactors: string;
+  }
+): Promise<CampaignMeta> => {
+  const results = await db.query(
+    db.format(
+      `SELECT COUNT(user_id) as count FROM wp_crowd_appq_has_candidate WHERE accepted = 1 AND campaign_id = ?`,
+      [campaign.id]
+    )
+  );
+
+  const testers = results.length ? formatCount(results) : 0;
+
+  // Get campaign allowed devices
+  const allowed_devices = getCampaignFormFactors(campaign.formFactors).filter(
+    (factor) => factor !== ""
+  );
+
+  return {
+    selected_testers: testers,
+    allowed_devices,
+  };
+};
+
+const getCampaignFormFactors = (factors: string): string[] => {
+  const formFactors = factors.split(",");
+
+  return formFactors.map((factor: string) => {
+    switch (parseInt(factor)) {
+      case DT_SMARTPHONE:
+        return "smartphone";
+      case DT_TABLET:
+        return "tablet";
+      case DT_DESKTOP:
+        return "desktop";
+      case DT_TV:
+        return "tv";
+      default:
+        return "";
+    }
+  });
+};

--- a/src/utils/campaigns/getWidgetCampaignProgress/index.ts
+++ b/src/utils/campaigns/getWidgetCampaignProgress/index.ts
@@ -1,0 +1,139 @@
+import * as db from "@src/features/db";
+
+interface bugsByUseCaseQueryResults {
+  total: number;
+  id: number;
+  title: string;
+  content: string;
+  simple_title: string;
+  info: string;
+  prefix: string;
+}
+
+// UC allowed responses 12.5 | 37.5 | 62.5 | 87.5
+
+const UC_PROGRESS_1 = { max: 25, value: 12.5 }; //  0%  - 24.99%
+const UC_PROGRESS_2 = { max: 50, value: 37.5 }; //  25% - 49.99%
+const UC_PROGRESS_3 = { max: 75, value: 62.5 }; //  50% - 74.99%
+const UC_PROGRESS_4 = { max: 100, value: 87.5 }; // 75% - 100%
+
+const getWidgetUseCaseProgress = async (
+  cp: StoplightComponents["schemas"]["CampaignWithOutput"]
+): Promise<number> => {
+  // Selected testers
+  const testersQuery = `SELECT 
+    p.id, 
+    c.group_id
+    FROM wp_crowd_appq_has_candidate c
+           JOIN wp_appq_evd_profile p ON (p.wp_user_id = c.user_id)
+    WHERE c.campaign_id = ?
+    AND accepted = 1 GROUP BY p.id`;
+
+  const testers = await db.query(db.format(testersQuery, [cp.id]));
+
+  if (!testers.length) {
+    return 0;
+  }
+
+  const defaultGroups = {
+    0: 0, // All
+    1: 0, // Group 1
+    2: 0, // Group 2
+    3: 0, // Group 3
+    4: 0, // Group 4
+  };
+
+  // reduce tester to group
+  const groups = testers.reduce(
+    (
+      acc: { [x: number]: number },
+      tester: { id: number; group_id: number }
+    ) => {
+      acc[0] += 1; // Every tester is in the all group
+
+      if (!acc[tester.group_id]) {
+        acc[tester.group_id] = 1;
+      } else {
+        acc[tester.group_id] += 1;
+      }
+      return acc;
+    },
+    defaultGroups
+  );
+
+  // Use cases status
+  const ucQuery = `SELECT 
+    uc.id, 
+    g.group_id, 
+    uc.campaign_id, 
+    COUNT(DISTINCT t.tester_id) as completions
+    FROM wp_appq_campaign_task uc
+      LEFT JOIN wp_appq_user_task t ON (t.task_id = uc.id AND t.is_completed = 1)
+      JOIN wp_appq_campaign_task_group g ON (g.task_id = uc.id)
+    WHERE uc.campaign_id = ?
+    group by uc.id`;
+
+  const uc = await db.query(db.format(ucQuery, [cp.id]));
+
+  if (!uc.length) {
+    return UC_PROGRESS_1.value;
+  }
+
+  const completion = {
+    expected: 0,
+    actual: 0,
+  };
+
+  uc.forEach((useCase: { group_id: number; completions: number }) => {
+    completion.expected += groups[useCase.group_id];
+    completion.actual += useCase.completions;
+  });
+
+  if (completion.expected === 0 || completion.actual === 0)
+    return UC_PROGRESS_1.value;
+
+  const progress = (completion.actual / completion.expected) * 100;
+
+  if (progress < UC_PROGRESS_1.max) return UC_PROGRESS_1.value;
+  else if (progress < UC_PROGRESS_2.max) return UC_PROGRESS_2.value;
+  else if (progress < UC_PROGRESS_3.max) return UC_PROGRESS_3.value;
+  else return UC_PROGRESS_4.value;
+};
+
+export const getWidgetCampaignProgress = async (
+  campaign: StoplightComponents["schemas"]["CampaignWithOutput"]
+): Promise<
+  StoplightComponents["schemas"]["WidgetCampaignProgress"] & {
+    kind: "campaignProgress";
+  }
+> => {
+  const error = {
+    code: 400,
+    message: "Something went wrong with campaign-progress widget",
+    error: true,
+  } as StoplightComponents["schemas"]["Error"];
+
+  const useCaseProgress = await getWidgetUseCaseProgress(campaign);
+
+  const startDate = new Date(campaign.start_date);
+  const endDate = new Date(campaign.end_date);
+  const now = new Date();
+
+  const expDuration = endDate.getTime() - startDate.getTime();
+  const actDuration = now.getTime() - startDate.getTime();
+
+  return {
+    data: [
+      {
+        start_date: campaign.start_date,
+        end_date: campaign.end_date,
+        usecase_completion: useCaseProgress,
+        time_elapsed: actDuration,
+        expected_duration: expDuration,
+      },
+    ],
+    kind: "campaignProgress",
+  } as StoplightComponents["schemas"]["WidgetCampaignProgress"] & {
+    kind: "campaignProgress";
+  };
+};

--- a/src/utils/campaigns/index.ts
+++ b/src/utils/campaigns/index.ts
@@ -13,6 +13,7 @@ import { getCampaignBugs } from "./getCampaignBugs";
 import { getTitleRule, getBugTitle } from "./getTitleRule";
 import { getWidgetBugsByDevice } from "./getWidgetBugsByDevice";
 import { getWidgetBugsByUseCase } from "./getWidgetBugsByUseCase";
+import { getCampaignMeta } from "./getCampaignMeta";
 
 export {
   checkCampaignRequest,
@@ -31,4 +32,5 @@ export {
   getBugTitle,
   getWidgetBugsByDevice,
   getWidgetBugsByUseCase,
+  getCampaignMeta,
 };

--- a/src/utils/campaigns/index.ts
+++ b/src/utils/campaigns/index.ts
@@ -14,6 +14,7 @@ import { getTitleRule, getBugTitle } from "./getTitleRule";
 import { getWidgetBugsByDevice } from "./getWidgetBugsByDevice";
 import { getWidgetBugsByUseCase } from "./getWidgetBugsByUseCase";
 import { getCampaignMeta } from "./getCampaignMeta";
+import { getWidgetCampaignProgress } from "./getWidgetCampaignProgress";
 
 export {
   checkCampaignRequest,
@@ -33,4 +34,5 @@ export {
   getWidgetBugsByDevice,
   getWidgetBugsByUseCase,
   getCampaignMeta,
+  getWidgetCampaignProgress,
 };


### PR DESCRIPTION
# /campaigns/{cid}/widgets
- Should answer 403 if user is not logged in (176 ms)
- Should answer 400 if campaign does not exist (44 ms)
- Should answer 403 if the user has no permissions to see the campaign (243 ms)
- Should answer 400 if the widget does not exist or has an invalid name (3 ms)
## Bugs by usecase
- Should answer 200 and return the bugs by use case widget (43 ms)
- Should answer 200 and the usecase title must be used in absence of simple title (6 ms)
- Should answer 200 and returns bugs even without any usecase specified (21 ms)
## Bugs by device
- Should answer 200 and return the bugs by device widget (5 ms)
- Should answer 200 and return the bugs by device widget (with 2 device type) (14 ms)
## Campaign progress
- Should answer 200 and return the correct kind of widget (14 ms)
- Should return 12,5 as uc progress when the cp has a 0% of completions (17 ms)
- Should return 37,5 as uc progress when the cp has a 25% of completions (26 ms)
- Should return 62,5 as uc progress when the cp has a 50% of completions (35 ms)
- Should return 87.5 as uc progress when the cp has a 75% of completions (40 ms)
- Should return 87.5 as uc progress when the cp has a 100% of completions (50 ms)
- Should return 0 time_elapsed and 0 expected_duration when the startDate is greater than endDate (15 ms)

- Should return a number greater than 0 when the cp dates are correct (15 ms)