### PR TITLE
Unique bugs widget

### DIFF
--- a/src/__mocks__/database/companyAdapter.ts
+++ b/src/__mocks__/database/companyAdapter.ts
@@ -56,6 +56,7 @@ import tags from "@src/__mocks__/database/bug_tags";
 import Templates from "@src/__mocks__/database/templates";
 import Category from "@src/__mocks__/database/template_categories";
 import userTask from "@src/__mocks__/database/user_task";
+import customerUniqueBugsRead from "@src/__mocks__/database/customer_unique_bug_read";
 
 interface dataObject {
   profiles?: Array<any>;
@@ -120,6 +121,7 @@ export const adapter = {
     await Category.mock();
     await tags.mock();
     await userTask.mock();
+    await customerUniqueBugsRead.mock();
   },
   drop: async () => {
     await profileTable.drop();
@@ -166,6 +168,7 @@ export const adapter = {
     await userTask.dropMock();
     await Templates.dropMock();
     await Category.dropMock();
+    await customerUniqueBugsRead.dropMock();
   },
 
   clear: async () => {

--- a/src/__mocks__/database/customer_unique_bug_read.ts
+++ b/src/__mocks__/database/customer_unique_bug_read.ts
@@ -1,0 +1,27 @@
+import Table from "./table";
+
+type CustomerUniqueBugsReadParams = {
+  wp_user_id?: number;
+  campaign_id?: number;
+  bugs_read?: number;
+};
+
+const defaultItem: CustomerUniqueBugsReadParams = {
+  wp_user_id: 0,
+  campaign_id: 0,
+  bugs_read: 0,
+};
+class CustomerUniqueBugsRead extends Table<CustomerUniqueBugsReadParams> {
+  protected name = "wp_appq_unique_bug_read";
+  protected columns = [
+    "wp_user_id INTEGER(11) NOT NULL",
+    "campaign_id INTEGER(11) NOT NULL",
+    "bugs_read INTEGER(11) NOT NULL",
+  ];
+  constructor() {
+    super(defaultItem);
+  }
+}
+const table = new CustomerUniqueBugsRead();
+export default table;
+export type { CustomerUniqueBugsReadParams };

--- a/src/__mocks__/database/customer_unique_bug_read.ts
+++ b/src/__mocks__/database/customer_unique_bug_read.ts
@@ -4,6 +4,7 @@ type CustomerUniqueBugsReadParams = {
   wp_user_id?: number;
   campaign_id?: number;
   bugs_read?: number;
+  update_time?: string;
 };
 
 const defaultItem: CustomerUniqueBugsReadParams = {
@@ -17,6 +18,7 @@ class CustomerUniqueBugsRead extends Table<CustomerUniqueBugsReadParams> {
     "wp_user_id INTEGER(11) NOT NULL",
     "campaign_id INTEGER(11) NOT NULL",
     "bugs_read INTEGER(11) NOT NULL",
+    "update_time TIMESTAMP NOT NULL",
   ];
   constructor() {
     super(defaultItem);

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -281,6 +281,7 @@ paths:
                   - $ref: '#/components/schemas/WidgetBugsByUseCase'
                   - $ref: '#/components/schemas/WidgetBugsByDevice'
                   - $ref: '#/components/schemas/WidgetCampaignProgress'
+                  - $ref: '#/components/schemas/WidgetCampaignUniqueBugs'
               examples:
                 Bugs by UseCase:
                   value:
@@ -325,6 +326,11 @@ paths:
         - JWT: []
       parameters:
         - $ref: '#/components/parameters/wslug'
+        - schema:
+            type: boolean
+          in: query
+          name: updateTrend
+          description: should update bug trend after request resolves?
   '/campaigns/{cid}/meta':
     parameters:
       - name: cid
@@ -1897,6 +1903,10 @@ components:
       properties:
         data:
           type: object
+          required:
+            - unique
+            - total
+            - trend
           properties:
             unique:
               type: number

--- a/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.spec.ts
@@ -3,7 +3,6 @@ import request from "supertest";
 import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
 import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
 import useCases, { UseCaseParams } from "@src/__mocks__/database/use_cases";
-import reports from "@src/__mocks__/database/report";
 import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
 import bugMedia from "@src/__mocks__/database/bug_media";
 import bugSeverity from "@src/__mocks__/database/bug_severity";

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -11,6 +11,7 @@ import { getProjectById } from "@src/utils/projects";
 import getCampaignBugsTrend from "./uniqueBugsWidget/getCampaignBugsTrend";
 import updateTrend from "./uniqueBugsWidget/updateTrend";
 import getCampaignBugSituation from "./uniqueBugsWidget/getCampaignBugSituation";
+import isGracePeriodPassed from "./uniqueBugsWidget/isGracePeriodPassed";
 
 export default async (
   c: Context,
@@ -84,7 +85,13 @@ export default async (
           userId: user.id,
           unique,
         });
-        if (shouldUpdateTrend) {
+        if (
+          shouldUpdateTrend &&
+          (await isGracePeriodPassed({
+            campaignId: campaign.id,
+            userId: user.id,
+          }))
+        ) {
           await updateTrend({
             campaignId: campaign.id,
             userId: user.id,

--- a/src/routes/campaigns/campaignId/widgets/_get/index.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/index.ts
@@ -8,6 +8,9 @@ import {
 } from "@src/utils/campaigns";
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getProjectById } from "@src/utils/projects";
+import getCampaignBugsTrend from "./uniqueBugsWidget/getCampaignBugsTrend";
+import updateTrend from "./uniqueBugsWidget/updateTrend";
+import getCampaignBugSituation from "./uniqueBugsWidget/getCampaignBugSituation";
 
 export default async (
   c: Context,
@@ -23,8 +26,17 @@ export default async (
   } as StoplightComponents["schemas"]["Error"];
 
   const cid = parseInt(c.request.params.cid as string);
-  const widget = c.request.query.s as string;
+  const widget = c.request.query
+    .s as StoplightComponents["parameters"]["wslug"];
+  const shouldUpdateTrend = c.request.query.hasOwnProperty("updateTrend");
 
+  if (widget !== "unique-bugs" && shouldUpdateTrend) {
+    res.status_code = 422;
+    throw {
+      message: "Invalid query parameter",
+      code: 422,
+    };
+  }
   res.status_code = 200;
 
   try {
@@ -50,7 +62,6 @@ export default async (
           "Campaign doesn't exist or you don't have permission to view it",
       };
     }
-
     // Check if user has permission to access the campaign
     await getProjectById({
       projectId: campaign.project.id,
@@ -65,6 +76,25 @@ export default async (
         return await getWidgetBugsByDevice(campaign);
       case "cp-progress":
         return await getWidgetCampaignProgress(campaign);
+      case "unique-bugs":
+        const { unique, total } = await getCampaignBugSituation(campaign);
+
+        const trend = await getCampaignBugsTrend({
+          campaignId: campaign.id,
+          userId: user.id,
+          unique,
+        });
+        if (shouldUpdateTrend) {
+          await updateTrend({
+            campaignId: campaign.id,
+            userId: user.id,
+            unique,
+          });
+        }
+        return {
+          data: { unique, total, trend },
+          kind: "campaignUniqueBugs",
+        };
     }
 
     throw {
@@ -74,9 +104,9 @@ export default async (
     };
   } catch (e: any) {
     res.status_code = e.code || 500;
-    error.code = e.code || 500;
+    error.code = typeof e.code === "number" ? e.code : 500;
     error.message = e.message || ERROR_MESSAGE;
 
-    return error;
+    throw error;
   }
 };

--- a/src/routes/campaigns/campaignId/widgets/_get/unique-bugs.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/unique-bugs.spec.ts
@@ -1,0 +1,174 @@
+import app from "@src/app";
+import request from "supertest";
+import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
+import bugs from "@src/__mocks__/database/bugs";
+
+describe("GET /campaigns/{cid}/widgets - unique bugs", () => {
+  beforeAll(async () => {
+    await dbAdapter.add({
+      campaigns: [
+        { id: 1, project_id: 1 },
+        { id: 2, project_id: 2 },
+        { id: 3, project_id: 1, cust_bug_vis: 1 },
+        { id: 4, project_id: 1 },
+      ],
+      companies: [{ id: 100, company: "company 1" }],
+      campaignTypes: [{ id: 1, name: "Test" }],
+      userToCustomers: [{ wp_user_id: 1, customer_id: 100 }],
+      projects: [
+        { id: 1, customer_id: 100 },
+        { id: 2, customer_id: 10 },
+      ],
+      userToProjects: [
+        {
+          wp_user_id: 1,
+          project_id: 1,
+        },
+      ],
+      profiles: [{ wp_user_id: 1, id: 32 }],
+    });
+    await bugs.insert({ id: 1, campaign_id: 1, wp_user_id: 5, status_id: 2 });
+    await bugs.insert({
+      id: 2,
+      campaign_id: 1,
+      wp_user_id: 5,
+      is_duplicated: 1,
+      status_id: 2,
+    });
+    await bugs.insert({
+      id: 3,
+      campaign_id: 1,
+      wp_user_id: 5,
+      is_duplicated: 1,
+      status_id: 2,
+    });
+    await bugs.insert({
+      id: 4,
+      campaign_id: 1,
+      wp_user_id: 5,
+      status_id: 1,
+    });
+    await bugs.insert({
+      id: 5,
+      campaign_id: 1,
+      wp_user_id: 5,
+      status_id: 3,
+    });
+    await bugs.insert({
+      id: 6,
+      campaign_id: 1,
+      wp_user_id: 5,
+      status_id: 4,
+    });
+
+    await bugs.insert({
+      id: 7,
+      campaign_id: 3,
+      wp_user_id: 5,
+      status_id: 4,
+    });
+    await bugs.insert({
+      id: 8,
+      campaign_id: 3,
+      wp_user_id: 5,
+      status_id: 2,
+    });
+    await bugs.insert({
+      id: 9,
+      campaign_id: 3,
+      wp_user_id: 5,
+      status_id: 1,
+    });
+  });
+
+  it("Should answer 403 if user is not logged in", async () => {
+    const response = await request(app).get(
+      `/campaigns/1/widgets?s=unique-bugs`
+    );
+    expect(response.status).toBe(403);
+  });
+
+  it("Should answer 403 if user doesnt have access to campaign", async () => {
+    const response = await request(app)
+      .get(`/campaigns/2/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(403);
+  });
+
+  it("Should answer 200 if user has access to campaign", async () => {
+    const response = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(200);
+  });
+
+  it("Should answer 422 if user query parameter updateTrend is set on other widgets", async () => {
+    for (const widget of ["bugs-by-usecase", "bugs-by-device", "cp-progress"]) {
+      const response = await request(app)
+        .get(`/campaigns/1/widgets?s=${widget}&updateTrend=true`)
+        .set("Authorization", "Bearer user");
+      expect(response.status).toBe(422);
+    }
+  });
+
+  it("Should return the number of accepted bugs on success", async () => {
+    const response = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(response.body).toHaveProperty("data");
+    expect(response.body.data).toHaveProperty("total", 3);
+  });
+
+  it("Should return the number of accepted unique bugs on success", async () => {
+    const response = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(response.body).toHaveProperty("data");
+    expect(response.body.data).toHaveProperty("unique", 1);
+  });
+
+  it("Should return show unique and total bugs in review if the campaign has the review visibility active", async () => {
+    const response = await request(app)
+      .get(`/campaigns/3/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(response.body).toHaveProperty("data");
+    expect(response.body.data).toHaveProperty("total", 2);
+    expect(response.body.data).toHaveProperty("unique", 2);
+  });
+
+  it("Should return the trend from the last trend update", async () => {
+    const response = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(response.body).toHaveProperty("data");
+    expect(response.body.data).toHaveProperty("trend", 1);
+  });
+
+  it("Should return update trend if requested", async () => {
+    const nonUpdatingResponse = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(nonUpdatingResponse.body).toHaveProperty("data");
+    expect(nonUpdatingResponse.body.data).toHaveProperty("trend", 1);
+    const responseBeforeUpdate = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs&updateTrend=true`)
+      .set("Authorization", "Bearer user");
+    expect(responseBeforeUpdate.body).toHaveProperty("data");
+    expect(responseBeforeUpdate.body.data).toHaveProperty("trend", 1);
+    const responseAfterUpdate = await request(app)
+      .get(`/campaigns/1/widgets?s=unique-bugs&updateTrend=true`)
+      .set("Authorization", "Bearer user");
+    expect(responseAfterUpdate.body).toHaveProperty("data");
+    expect(responseAfterUpdate.body.data).toHaveProperty("trend", 0);
+  });
+
+  it("Should return 0 as bugs and unique if campaign is without bugs", async () => {
+    const nonUpdatingResponse = await request(app)
+      .get(`/campaigns/4/widgets?s=unique-bugs`)
+      .set("Authorization", "Bearer user");
+    expect(nonUpdatingResponse.body).toHaveProperty("data");
+    expect(nonUpdatingResponse.body.data).toHaveProperty("total", 0);
+    expect(nonUpdatingResponse.body.data).toHaveProperty("unique", 0);
+    expect(nonUpdatingResponse.body.data).toHaveProperty("trend", 0);
+  });
+});

--- a/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/getCampaignBugSituation.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/getCampaignBugSituation.ts
@@ -1,0 +1,26 @@
+import * as db from "@src/features/db";
+
+async function getCampaignBugSituation(campaign: {
+  id: number;
+  showNeedReview: boolean;
+}) {
+  const bugs = await db.query(
+    db.format(
+      `SELECT is_duplicated FROM wp_appq_evd_bug 
+            WHERE campaign_id = ? AND ${
+              campaign.showNeedReview
+                ? "(status_id = 2 OR status_id = 4)"
+                : "status_id = 2"
+            } 
+            `,
+      [campaign.id]
+    )
+  );
+
+  const unique = bugs.filter(
+    (bug: { is_duplicated: 1 | 0 }) => bug.is_duplicated != 1
+  );
+  return { unique: unique.length, total: bugs.length };
+}
+
+export default getCampaignBugSituation;

--- a/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/getCampaignBugsTrend.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/getCampaignBugsTrend.ts
@@ -1,0 +1,29 @@
+import * as db from "@src/features/db";
+
+async function getCampaignBugsTrend({
+  campaignId,
+  userId,
+  unique,
+}: {
+  campaignId: number;
+  userId: number;
+  unique: number;
+}) {
+  const lastReadBugs = await db.query(
+    db.format(
+      `SELECT bugs_read 
+                FROM wp_appq_unique_bug_read 
+                WHERE campaign_id = ? AND wp_user_id = ?
+              `,
+      [campaignId, userId]
+    ),
+    "unguess"
+  );
+  let trend = unique;
+  if (lastReadBugs.length > 0) {
+    trend = trend - lastReadBugs[0].bugs_read;
+  }
+  return trend;
+}
+
+export default getCampaignBugsTrend;

--- a/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/isGracePeriodPassed.spec.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/isGracePeriodPassed.spec.ts
@@ -1,0 +1,36 @@
+import isGracePeriodPassed from "./isGracePeriodPassed";
+import uniqueBugsRead from "@src/__mocks__/database/customer_unique_bug_read";
+
+describe("isGracePeriodPassed", () => {
+  beforeAll(() => {
+    const yesterday = new Date().setDate(new Date().getDate() - 1);
+    const now = new Date();
+    const formatDateTime = (t: Date | number) =>
+      new Date(t).getTime().toString();
+
+    uniqueBugsRead.insert({
+      campaign_id: 1,
+      wp_user_id: 1,
+      bugs_read: 0,
+      update_time: formatDateTime(yesterday),
+    });
+    uniqueBugsRead.insert({
+      campaign_id: 2,
+      wp_user_id: 1,
+      bugs_read: 0,
+      update_time: formatDateTime(now),
+    });
+  });
+  it("Should return true if the current campaign was updated at least one minute ago", async () => {
+    const result = await isGracePeriodPassed({ campaignId: 1, userId: 1 });
+    expect(result).toBe(true);
+  });
+  it("Should return false if the current campaign was updated less than one minute ago", async () => {
+    const result = await isGracePeriodPassed({ campaignId: 2, userId: 1 });
+    expect(result).toBe(false);
+  });
+  it("Should return true if the current campaign was never updated", async () => {
+    const result = await isGracePeriodPassed({ campaignId: 3, userId: 1 });
+    expect(result).toBe(true);
+  });
+});

--- a/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/isGracePeriodPassed.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/isGracePeriodPassed.ts
@@ -1,0 +1,27 @@
+import * as db from "@src/features/db";
+export default async ({
+  campaignId,
+  userId,
+}: {
+  campaignId: number;
+  userId: number;
+}) => {
+  const result = await db.query(
+    db.format(
+      `SELECT update_time
+      FROM wp_appq_unique_bug_read
+      WHERE campaign_id = ? AND wp_user_id = ?
+    `,
+      [campaignId, userId]
+    ),
+    "unguess"
+  );
+  if (result.length === 0) {
+    return true;
+  }
+
+  const now = new Date();
+  const lastUpdate = new Date(result[0].update_time);
+
+  return now.getTime() - lastUpdate.getTime() > 60000;
+};

--- a/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/updateTrend.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/updateTrend.ts
@@ -1,0 +1,47 @@
+import * as db from "@src/features/db";
+
+async function updateTrend({
+  campaignId,
+  userId,
+  unique,
+}: {
+  campaignId: number;
+  userId: number;
+  unique: number;
+}) {
+  const trend = await db.query(
+    db.format(
+      `SELECT bugs_read 
+                FROM wp_appq_unique_bug_read 
+                WHERE campaign_id = ? AND wp_user_id = ?
+              `,
+      [campaignId, userId]
+    ),
+    "unguess"
+  );
+  if (trend.length > 0) {
+    await db.query(
+      db.format(
+        `UPDATE wp_appq_unique_bug_read 
+                    SET bugs_read = ? 
+                    WHERE campaign_id = ? AND wp_user_id = ?
+                  `,
+        [unique, campaignId, userId]
+      ),
+      "unguess"
+    );
+  } else {
+    await db.query(
+      db.format(
+        `INSERT INTO wp_appq_unique_bug_read 
+                    (bugs_read, campaign_id, wp_user_id) 
+                    VALUES (?, ?, ?)
+                  `,
+        [unique, campaignId, userId]
+      ),
+      "unguess"
+    );
+  }
+}
+
+export default updateTrend;

--- a/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/updateTrend.ts
+++ b/src/routes/campaigns/campaignId/widgets/_get/uniqueBugsWidget/updateTrend.ts
@@ -19,14 +19,15 @@ async function updateTrend({
     ),
     "unguess"
   );
+  const now = new Date().getTime().toString();
   if (trend.length > 0) {
     await db.query(
       db.format(
         `UPDATE wp_appq_unique_bug_read 
-                    SET bugs_read = ? 
+                    SET bugs_read = ? , update_time = ?
                     WHERE campaign_id = ? AND wp_user_id = ?
                   `,
-        [unique, campaignId, userId]
+        [unique, now, campaignId, userId]
       ),
       "unguess"
     );
@@ -34,10 +35,10 @@ async function updateTrend({
     await db.query(
       db.format(
         `INSERT INTO wp_appq_unique_bug_read 
-                    (bugs_read, campaign_id, wp_user_id) 
-                    VALUES (?, ?, ?)
+                    (bugs_read, update_time, campaign_id, wp_user_id) 
+                    VALUES (?, ?, ?, ?)
                   `,
-        [unique, campaignId, userId]
+        [unique, now, campaignId, userId]
       ),
       "unguess"
     );

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -607,9 +607,9 @@ export interface components {
      */
     WidgetCampaignUniqueBugs: {
       data: {
-        unique?: number;
-        total?: number;
-        trend?: number;
+        unique: number;
+        total: number;
+        trend: number;
       };
       /**
        * @default campaignUniqueBugs
@@ -878,6 +878,8 @@ export interface operations {
       query: {
         /** Campaign widget slug */
         s: components["parameters"]["wslug"];
+        /** should update bug trend after request resolves? */
+        updateTrend?: boolean;
       };
     };
     responses: {
@@ -887,7 +889,8 @@ export interface operations {
           "application/json":
             | components["schemas"]["WidgetBugsByUseCase"]
             | components["schemas"]["WidgetBugsByDevice"]
-            | components["schemas"]["WidgetCampaignProgress"];
+            | components["schemas"]["WidgetCampaignProgress"]
+            | components["schemas"]["WidgetCampaignUniqueBugs"];
         };
       };
       400: components["responses"]["Error"];


### PR DESCRIPTION
"GET /campaigns/{cid}/widgets - unique bugs Should answer 403 if user is not logged in"
"GET /campaigns/{cid}/widgets - unique bugs Should answer 403 if user doesnt have access to campaign"
"GET /campaigns/{cid}/widgets - unique bugs Should answer 200 if user has access to campaign"
"GET /campaigns/{cid}/widgets - unique bugs Should answer 422 if user query parameter updateTrend is set on other widgets"
"GET /campaigns/{cid}/widgets - unique bugs Should return the number of accepted bugs on success"
"GET /campaigns/{cid}/widgets - unique bugs Should return the number of accepted unique bugs on success"
"GET /campaigns/{cid}/widgets - unique bugs Should return show unique and total bugs in review if the campaign has the review visibility active"
"GET /campaigns/{cid}/widgets - unique bugs Should return the trend from the last trend update"
"GET /campaigns/{cid}/widgets - unique bugs Should update trend if requested"
"GET /campaigns/{cid}/widgets - unique bugs Should return 0 as bugs and unique if campaign is without bugs",
"GET /campaigns/{cid}/widgets - unique bugs Should not update trend if grace period is not past"

"isGracePeriodPassed Should return true if the current campaign was updated at least one minute ago"
"isGracePeriodPassed Should return false if the current campaign was updated less than one minute ago"
"isGracePeriodPassed Should return true if the current campaign was never updated"