### PR TITLE
UN-284 patch bug

### DIFF
--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -337,22 +337,24 @@ paths:
                 tags:
                   type: array
                   items:
-                    anyOf:
+                    oneOf:
                       - properties:
                           tag_id:
                             type: number
+                        required:
+                          - tag_id
                       - properties:
                           tag_name:
                             type: string
+                        required:
+                          - tag_name
                     type: object
             examples:
               possibleTagEntries:
                 value:
                   tags:
-                    - tid: 1
+                    - tag_id: 1
                     - tag_name: tag2
-                    - tid: 3
-                      tag_name: tag3
               emptyTagsEntries:
                 value:
                   tags: []

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -358,6 +358,8 @@ paths:
               emptyTagsEntries:
                 value:
                   tags: []
+      security:
+        - JWT: []
   '/campaigns/{cid}/meta':
     parameters:
       - name: cid

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -296,6 +296,66 @@ paths:
       operationId: get-campaigns-single-bug
       security:
         - JWT: []
+    patch:
+      summary: Patch Campaigns Single Bug
+      operationId: patch-campaigns-cid-bugs-bid
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  tags:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        tag_id:
+                          type: number
+                        tag_name:
+                          type: string
+                      required:
+                        - tag_id
+                        - tag_name
+              examples:
+                oneTagResponse:
+                  value:
+                    tags:
+                      - tag_id: 0
+                        tag_name: string
+                emptyTagsResponse:
+                  value:
+                    tags: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tags:
+                  type: array
+                  items:
+                    anyOf:
+                      - properties:
+                          tag_id:
+                            type: number
+                      - properties:
+                          tag_name:
+                            type: string
+                    type: object
+            examples:
+              possibleTagEntries:
+                value:
+                  tags:
+                    - tid: 1
+                    - tag_name: tag2
+                    - tid: 3
+                      tag_name: tag3
+              emptyTagsEntries:
+                value:
+                  tags: []
   '/campaigns/{cid}/meta':
     parameters:
       - name: cid

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -163,7 +163,6 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
 
     expect(response.status).toBe(403);
   });
-
   // It should fail if the campaign does not exist
   it("Should fail if the campaign does not exist", async () => {
     const response = await request(app)
@@ -172,7 +171,6 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
 
     expect(response.status).toBe(400);
   });
-
   // It should fail if the bug does not exist
   it("Should fail if the bug does not exist", async () => {
     const response = await request(app)
@@ -188,7 +186,6 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .set("Authorization", "Bearer user");
     expect(response.status).toBe(403);
   });
-
   it("Should remove all tags if send empty tags", async () => {
     const response = await request(app)
       .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
@@ -199,7 +196,6 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     expect(response.status).toBe(200);
     expect(response.body.tags).toEqual([]);
   });
-
   it("Should add existing tag by tag_id", async () => {
     const response = await request(app)
       .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
@@ -264,7 +260,6 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       ])
     );
   });
-
   it("Should ignore duplicated tag_id", async () => {
     const response = await request(app)
       .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -129,7 +129,7 @@ const tag_1 = {
 };
 const tag_2_other_cp = {
   id: 1,
-  tag_id: 2,
+  tag_id: 45,
   display_name: "Tag 2",
   campaign_id: campaign_2.id,
   bug_id: 1000,
@@ -205,15 +205,17 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
       .set("Authorization", "Bearer user")
       .send({
-        tags: [{ tag_id: 2 }],
+        tags: [{ tag_id: tag_2_other_cp.tag_id }],
       });
     expect(response.status).toBe(200);
-    expect(response.body.tags).toEqual([
-      {
-        tag_id: tag_2_other_cp.tag_id,
-        tag_name: tag_2_other_cp.display_name,
-      },
-    ]);
+    expect(response.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag_id: tag_2_other_cp.tag_id,
+          tag_name: tag_2_other_cp.display_name,
+        }),
+      ])
+    );
   });
   it("Should add existing tag by tag_name", async () => {
     const response = await request(app)
@@ -223,12 +225,44 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
         tags: [{ tag_name: tag_2_other_cp.display_name }],
       });
     expect(response.status).toBe(200);
-    expect(response.body.tags).toEqual([
-      {
-        tag_id: tag_2_other_cp.tag_id,
-        tag_name: tag_2_other_cp.display_name,
-      },
-    ]);
+    expect(response.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag_id: tag_2_other_cp.tag_id,
+          tag_name: tag_2_other_cp.display_name,
+        }),
+      ])
+    );
+  });
+  it("Should add tag by tag_name if tag does not exists", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({
+        tags: [
+          { tag_id: tag_2_other_cp.tag_id },
+          { tag_name: "Tag to be add" },
+          { tag_name: "Tag to be add 2" },
+        ],
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag_id: 47,
+          tag_name: "Tag to be add 2",
+        }),
+        expect.objectContaining({
+          //existing tag
+          tag_id: tag_2_other_cp.tag_id,
+          tag_name: tag_2_other_cp.display_name,
+        }),
+        expect.objectContaining({
+          tag_id: 46,
+          tag_name: "Tag to be add",
+        }),
+      ])
+    );
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -4,7 +4,6 @@ import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
 import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
 import bugType from "@src/__mocks__/database/bug_type";
 import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
-import * as db from "@src/features/db";
 import severities from "@src/__mocks__/database/bug_severity";
 import replicabilities from "@src/__mocks__/database/bug_replicability";
 import statuses from "@src/__mocks__/database/bug_status";
@@ -120,6 +119,31 @@ const bug_1: BugsParams = {
   os: device_1.operating_system,
   os_version: device_1.os_version,
 };
+
+const bug_2: BugsParams = {
+  id: 2,
+  internal_id: "UG2",
+  wp_user_id: 1,
+  message: "[CON-TEXT][2ndContext] - Bug 12-999 message",
+  description: "Bug 12999 description",
+  expected_result: "Bug 12999 expected result",
+  current_result: "Bug 12999 actual result",
+  campaign_id: campaign_2.id,
+  status_id: 2,
+  created: "2021-10-19 12:57:57.0",
+  updated: "2021-10-19 12:57:57.0",
+  dev_id: device_1.id,
+  severity_id: 1,
+  bug_replicability_id: 1,
+  bug_type_id: 1,
+  application_section_id: usecase_1.id,
+  application_section: usecase_1.title,
+  note: "Bug 12999 notes",
+  manufacturer: device_1.manufacturer,
+  model: device_1.model,
+  os: device_1.operating_system,
+  os_version: device_1.os_version,
+};
 const tag_1 = {
   id: 69,
   tag_id: 1,
@@ -146,6 +170,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     });
     await bugType.addDefaultItems();
     await bugs.insert(bug_1);
+    await bugs.insert(bug_2);
     await severities.addDefaultItems();
     await replicabilities.addDefaultItems();
     await statuses.addDefaultItems();
@@ -182,7 +207,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   // it Should fail if the user is not the owner
   it("Should fail if the user is not the owner", async () => {
     const response = await request(app)
-      .patch(`/campaigns/${campaign_2.id}/bugs/${bug_1.id}`)
+      .patch(`/campaigns/${campaign_2.id}/bugs/${bug_2.id}`)
       .set("Authorization", "Bearer user");
     expect(response.status).toBe(403);
   });

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -1,0 +1,175 @@
+import app from "@src/app";
+import request from "supertest";
+import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
+import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
+import bugType from "@src/__mocks__/database/bug_type";
+import bugs from "@src/__mocks__/database/bugs";
+
+const campaign_type_1 = {
+  id: 1,
+  name: "Functional Testing (Bug Hunting)",
+  type: FUNCTIONAL_CAMPAIGN_TYPE_ID,
+};
+const customer_1 = {
+  id: 1,
+  company: "Company 1",
+  company_logo: "logo999.png",
+  tokens: 100,
+};
+
+const user_to_customer_1 = {
+  wp_user_id: 1,
+  customer_id: 1,
+};
+
+const project_1 = {
+  id: 1,
+  display_name: "Project 999",
+  customer_id: 1,
+};
+const customer_2 = {
+  id: 2,
+  company: "Company 2",
+  company_logo: "logo999.png",
+  tokens: 100,
+};
+
+const user_to_customer_2 = {
+  wp_user_id: 2,
+  customer_id: 2,
+};
+
+const project_2 = {
+  id: 2,
+  display_name: "Project 2",
+  customer_id: 2,
+};
+
+const campaign_1 = {
+  id: 1,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 1 title",
+  customer_title: "Campaign 1 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: 1,
+};
+const campaign_2 = {
+  id: 2,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 2 title",
+  customer_title: "Campaign 2 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: 2,
+};
+const bug_1 = {
+  id: 1,
+  campaign_id: 1,
+  bug_type_id: 1,
+  title: "Bug 1 title",
+  description: "Bug 1 description",
+  status_id: 1,
+  priority_id: 1,
+  severity_id: 1
+}
+
+describe("GET /campaigns/{cid}/bug/{bid}", () => {
+  beforeAll(async () => {
+    await dbAdapter.add({
+      campaignTypes: [campaign_type_1],
+      campaigns: [campaign_1, campaign_2],
+      companies: [customer_1, customer_2],
+      projects: [project_1, project_2],
+      userToCustomers: [user_to_customer_1, user_to_customer_2],
+    });
+    await bugType.addDefaultItems();
+    await bugs.insert(bug_1);
+  });
+
+  // It should answer 403 if user is not logged in
+  it("Should answer 403 if user is not logged in", async () => {
+    const response = await request(app).patch(
+      `/campaigns/${campaign_1.id}/bug/${bug_1.id}`
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  // It should fail if the campaign does not exist
+  it("Should fail if the campaign does not exist", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/999/bug/666`)
+      .set("Authorization", "Bearer user");
+
+    expect(response.status).toBe(400);
+  });
+
+  // it should return 200 if the user is the owner
+  it("Should return 200 if the user is the owner", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bug/${bug_1.id}`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(200);
+  });
+
+  // it Should fail if the user is not the owner
+  it("Should fail if the user is not the owner", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bug/${bug_1.id}`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(403);
+  });
+
+  //should return campaign bugTypes
+  it("Should return campaign bugTypes", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bug/${bug_1.id}`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      {
+        id: 1,
+        name: "Crash",
+      },
+      {
+        id: 3,
+        name: "Graphic",
+      },
+      {
+        id: 5,
+        name: "Performance",
+      },
+      {
+        id: 6,
+        name: "Malfunction",
+      },
+      {
+        id: 7,
+        name: "Typo",
+      },
+      {
+        id: 8,
+        name: "Other",
+      },
+      {
+        id: 9,
+        name: "Security",
+      },
+      {
+        id: 10,
+        name: "Usability",
+      },
+    ]);
+  });
+
+  // --- End of file
+});

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -124,10 +124,10 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   beforeAll(async () => {
     await dbAdapter.add({
       campaignTypes: [campaign_type_1],
-      campaigns: [campaign_1],
-      companies: [customer_1],
-      projects: [project_1],
-      userToCustomers: [user_to_customer_1],
+      campaigns: [campaign_1, campaign_2],
+      companies: [customer_1, customer_2],
+      projects: [project_1, project_2],
+      userToCustomers: [user_to_customer_1, user_to_customer_2],
     });
     await bugType.addDefaultItems();
     await bugs.insert(bug_1);
@@ -163,6 +163,13 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .set("Authorization", "Bearer user");
 
     expect(response.status).toBe(400);
+  });
+  // it Should fail if the user is not the owner
+  it("Should fail if the user is not the owner", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_2.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(403);
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -265,5 +265,32 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     );
   });
 
+  it("Should ignore duplicated tag_id", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({
+        tags: [
+          { tag_id: tag_2_other_cp.tag_id },
+          { tag_name: "Tag to be add" },
+          { tag_id: tag_2_other_cp.tag_id },
+        ],
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.tags.length).toEqual(2);
+    expect(response.body.tags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          //existing tag
+          tag_id: tag_2_other_cp.tag_id,
+          tag_name: tag_2_other_cp.display_name,
+        }),
+      ])
+    );
+    expect(
+      response.body.tags[0].tag_id !== response.body.tags[1].tag_id
+    ).toEqual(true);
+  });
+
   // --- End of file
 });

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -10,6 +10,7 @@ import replicabilities from "@src/__mocks__/database/bug_replicability";
 import statuses from "@src/__mocks__/database/bug_status";
 import devices, { DeviceParams } from "@src/__mocks__/database/device";
 import usecases, { UseCaseParams } from "@src/__mocks__/database/use_cases";
+import tags from "@src/__mocks__/database/bug_tags";
 
 const campaign_type_1 = {
   id: 1,
@@ -119,6 +120,13 @@ const bug_1: BugsParams = {
   os: device_1.operating_system,
   os_version: device_1.os_version,
 };
+const tag_1 = {
+  id: 69,
+  tag_id: 1,
+  display_name: "Tag 1",
+  campaign_id: campaign_1.id,
+  bug_id: bug_1.id,
+};
 
 describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   beforeAll(async () => {
@@ -136,6 +144,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     await statuses.addDefaultItems();
     await devices.insert(device_1);
     await usecases.insert(usecase_1);
+    await tags.insert(tag_1);
   });
 
   // It should answer 403 if user is not logged in
@@ -170,6 +179,17 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .patch(`/campaigns/${campaign_2.id}/bugs/${bug_1.id}`)
       .set("Authorization", "Bearer user");
     expect(response.status).toBe(403);
+  });
+
+  it("Should remove all tags if send empty tags", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({
+        tags: [],
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.tags).toEqual([]);
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -144,6 +144,32 @@ const bug_2: BugsParams = {
   os: device_1.operating_system,
   os_version: device_1.os_version,
 };
+
+const bug_3: BugsParams = {
+  id: 3,
+  internal_id: "UG13",
+  wp_user_id: 1,
+  message: "[CON-TEXT][2ndContext] - Bug 12-999 message",
+  description: "Bug 12999 description",
+  expected_result: "Bug 12999 expected result",
+  current_result: "Bug 12999 actual result",
+  campaign_id: campaign_1.id,
+  status_id: 2,
+  created: "2021-10-19 12:57:57.0",
+  updated: "2021-10-19 12:57:57.0",
+  dev_id: device_1.id,
+  severity_id: 1,
+  bug_replicability_id: 1,
+  bug_type_id: 1,
+  application_section_id: usecase_1.id,
+  application_section: usecase_1.title,
+  note: "Bug 12999 notes",
+  manufacturer: device_1.manufacturer,
+  model: device_1.model,
+  os: device_1.operating_system,
+  os_version: device_1.os_version,
+};
+
 const tag_1 = {
   id: 69,
   tag_id: 1,
@@ -159,6 +185,14 @@ const tag_2_other_cp = {
   bug_id: 1000,
 };
 
+const tag_3 = {
+  id: 3,
+  tag_id: 2,
+  display_name: "Tag 3",
+  campaign_id: campaign_1.id,
+  bug_id: bug_3.id,
+};
+
 describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   beforeAll(async () => {
     await dbAdapter.add({
@@ -171,6 +205,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     await bugType.addDefaultItems();
     await bugs.insert(bug_1);
     await bugs.insert(bug_2);
+    await bugs.insert(bug_3);
     await severities.addDefaultItems();
     await replicabilities.addDefaultItems();
     await statuses.addDefaultItems();
@@ -178,6 +213,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     await usecases.insert(usecase_1);
     await tags.insert(tag_1);
     await tags.insert(tag_2_other_cp);
+    await tags.insert(tag_3);
   });
 
   // It should answer 403 if user is not logged in
@@ -226,31 +262,14 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
       .set("Authorization", "Bearer user")
       .send({
-        tags: [{ tag_id: tag_2_other_cp.tag_id }],
+        tags: [{ tag_id: tag_3.tag_id }],
       });
     expect(response.status).toBe(200);
     expect(response.body.tags).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          tag_id: tag_2_other_cp.tag_id,
-          tag_name: tag_2_other_cp.display_name,
-        }),
-      ])
-    );
-  });
-  it("Should add existing tag by tag_name", async () => {
-    const response = await request(app)
-      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
-      .set("Authorization", "Bearer user")
-      .send({
-        tags: [{ tag_name: tag_2_other_cp.display_name }],
-      });
-    expect(response.status).toBe(200);
-    expect(response.body.tags).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          tag_id: tag_2_other_cp.tag_id,
-          tag_name: tag_2_other_cp.display_name,
+          tag_id: tag_3.tag_id,
+          tag_name: tag_3.display_name,
         }),
       ])
     );
@@ -261,7 +280,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .set("Authorization", "Bearer user")
       .send({
         tags: [
-          { tag_id: tag_2_other_cp.tag_id },
+          { tag_id: tag_3.tag_id },
           { tag_name: "Tag to be add" },
           { tag_name: "Tag to be add 2" },
         ],
@@ -275,8 +294,8 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
         }),
         expect.objectContaining({
           //existing tag
-          tag_id: tag_2_other_cp.tag_id,
-          tag_name: tag_2_other_cp.display_name,
+          tag_id: tag_3.tag_id,
+          tag_name: tag_3.display_name,
         }),
         expect.objectContaining({
           tag_id: 46,
@@ -291,9 +310,9 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .set("Authorization", "Bearer user")
       .send({
         tags: [
-          { tag_id: tag_2_other_cp.tag_id },
+          { tag_id: tag_3.tag_id },
           { tag_name: "Tag to be add" },
-          { tag_id: tag_2_other_cp.tag_id },
+          { tag_id: tag_3.tag_id },
         ],
       });
     expect(response.status).toBe(200);
@@ -302,8 +321,8 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       expect.arrayContaining([
         expect.objectContaining({
           //existing tag
-          tag_id: tag_2_other_cp.tag_id,
-          tag_name: tag_2_other_cp.display_name,
+          tag_id: tag_3.tag_id,
+          tag_name: tag_3.display_name,
         }),
       ])
     );

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -127,6 +127,13 @@ const tag_1 = {
   campaign_id: campaign_1.id,
   bug_id: bug_1.id,
 };
+const tag_2_other_cp = {
+  id: 1,
+  tag_id: 2,
+  display_name: "Tag 2",
+  campaign_id: campaign_2.id,
+  bug_id: 1000,
+};
 
 describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   beforeAll(async () => {
@@ -145,6 +152,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     await devices.insert(device_1);
     await usecases.insert(usecase_1);
     await tags.insert(tag_1);
+    await tags.insert(tag_2_other_cp);
   });
 
   // It should answer 403 if user is not logged in
@@ -190,6 +198,37 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       });
     expect(response.status).toBe(200);
     expect(response.body.tags).toEqual([]);
+  });
+
+  it("Should add existing tag by tag_id", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({
+        tags: [{ tag_id: 2 }],
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.tags).toEqual([
+      {
+        tag_id: tag_2_other_cp.tag_id,
+        tag_name: tag_2_other_cp.display_name,
+      },
+    ]);
+  });
+  it("Should add existing tag by tag_name", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({
+        tags: [{ tag_name: tag_2_other_cp.display_name }],
+      });
+    expect(response.status).toBe(200);
+    expect(response.body.tags).toEqual([
+      {
+        tag_id: tag_2_other_cp.tag_id,
+        tag_name: tag_2_other_cp.display_name,
+      },
+    ]);
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -20,7 +20,7 @@ export default class Route extends UserRoute<{
     const params = this.getParameters();
     this.cid = parseInt(params.cid);
     this.bid = parseInt(params.bid);
-    this.tags = this.getBody().tags;
+    this.tags = this.removeDuplicatedId(this.getBody().tags);
   }
 
   protected async filter(): Promise<boolean> {
@@ -134,5 +134,19 @@ export default class Route extends UserRoute<{
       })
     );
     return query + values.join(",");
+  }
+  removeDuplicatedId(
+    tags: ({ tag_id: number } | { tag_name: string })[] | undefined
+  ): ({ tag_id: number } | { tag_name: string })[] | undefined {
+    if (!tags || tags?.length === 0) return undefined;
+    const tagsId = tags.map((tag) => {
+      if ("tag_id" in tag) return tag.tag_id;
+      return tag.tag_name;
+    });
+    const uniqueTagsId = [...new Set(tagsId)];
+    return uniqueTagsId.map((tagIdOrName) => {
+      if (typeof tagIdOrName === "number") return { tag_id: tagIdOrName };
+      return { tag_name: tagIdOrName };
+    });
   }
 }

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -144,15 +144,18 @@ export default class Route extends UserRoute<{
   `);
   }
 
-  private async getTagByNameOrId(tag: { tag_id?: number; tag_name?: string }) {
+  private async getTagByNameOrId(
+    tag: { tag_id: number } | { tag_name: string }
+  ) {
     const result: { tag_id: number; tag_name: string }[] = await db.query(
-      `SELECT tag_id, display_name as tag_name 
-      FROM wp_appq_bug_taxonomy 
-      WHERE ${
-        tag.tag_id
-          ? `tag_id = ${tag.tag_id} AND campaign_id = ${this.cid}`
-          : `display_name = '${tag.tag_name}' AND campaign_id = ${this.cid}`
-      } `
+      db.format(
+        `SELECT tag_id, display_name as tag_name 
+    FROM wp_appq_bug_taxonomy 
+    WHERE ${
+      "tag_id" in tag ? `tag_id = ?` : `display_name = ?`
+    }  AND campaign_id = ?`,
+        ["tag_id" in tag ? tag.tag_id : tag.tag_name, this.cid]
+      )
     );
     if (!result.length) return false;
     return result[0];

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -1,31 +1,29 @@
-/** OPENAPI-CLASS: patch-campaigns-cid-bug-types */
+/** OPENAPI-CLASS: patch-campaigns-cid-bugs-bid */
 import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getCampaign } from "@src/utils/campaigns";
 import UserRoute from "@src/features/routes/UserRoute";
 import { getProjectById } from "@src/utils/projects";
-import * as db from "@src/features/db";
 import { getBugById } from "@src/utils/bugs";
 
 export default class Route extends UserRoute<{
   parameters: StoplightOperations["patch-campaigns-cid-bugs-bid"]["parameters"]["path"];
-  body: StoplightOperations["patch-campaigns-cid-bugs-bid"]["requestBody"]["content"]["application/json"];
-  response: StoplightOperations["patch-campaigns-cid-bugs-bid"]["responses"]["200"]["content"]["application/json"];
+  // body: StoplightOperations["patch-campaigns-cid-bugs-bid"]["requestBody"]["content"]["application/json"];
+  // response: StoplightOperations["patch-campaigns-cid-bugs-bid"]["responses"]["200"]["content"]["application/json"];
 }> {
   private cid: number;
   private bid: number;
-  public tags: ({ tag_id?: number } | { tag_name?: string })[] | undefined;
+  // public tags: ({ tag_id?: number } | { tag_name?: string })[] | undefined;
 
   constructor(configuration: RouteClassConfiguration) {
     super(configuration);
     const params = this.getParameters();
     this.cid = parseInt(params.cid);
     this.bid = parseInt(params.bid);
-    this.tags = this.getBody().tags;
+    // this.tags = this.getBody().tags;
   }
 
   protected async filter(): Promise<boolean> {
     if (!super.filter()) return false;
-
     const campaign = await getCampaign({ campaignId: this.cid });
     if (!campaign) {
       this.setError(400, {
@@ -34,9 +32,9 @@ export default class Route extends UserRoute<{
       } as OpenapiError);
       return false;
     }
-
-    const bug = await getBugById({ bugId: this.bid });
-    if (!bug) {
+    try {
+      await getBugById({ bugId: this.bid });
+    } catch (e) {
       this.setError(400, {
         status_code: 400,
         message: ERROR_MESSAGE,
@@ -44,34 +42,18 @@ export default class Route extends UserRoute<{
       return false;
     }
 
-    try {
-      // Check if user has permission to edit the campaign
-      await getProjectById({
-        projectId: campaign.project.id,
-        user: this.getUser(),
-      });
-    } catch (e) {
-      this.setError(403, {
-        message: ERROR_MESSAGE,
-      } as OpenapiError);
-      return false;
-    }
+    // try {
+    //   // Check if user has permission to edit the campaign
+    //   await getProjectById({
+    //     projectId: campaign.project.id,
+    //     user: this.getUser(),
+    //   });
+    // } catch (e) {
+    //   this.setError(403, {
+    //     message: ERROR_MESSAGE,
+    //   } as OpenapiError);
+    //   return false;
+    // }
     return true;
-  }
-
-  protected async prepare(): Promise<void> {
-    const bugTags = await db.query(
-      db.format(
-        `
-      SELECT tag_id, display_name AS tag_name
-        FROM wp_appq_bug_taxonomy
-        WHERE is_public = 1 
-            AND campaign_id = ?
-            AND bug_id = ?
-        `,
-        [this.cid, this.bid]
-      )
-    );
-    return this.setSuccess(200, { tags: bugTags });
   }
 }

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -122,19 +122,20 @@ export default class Route extends UserRoute<{
         };
       }
       if (tagToAdd) {
-        values.push(`
-        (
-          ${tagToAdd.id}, 
-          '${tagToAdd.name}', 
-          '${tagToAdd.name}', 
-          ${this.bid}, 
-          ${this.cid}, 
-          ${this.getWordpressId("unguess")}, 
-          ${this.getUserId()}, 
-          1
-        )`);
+        values.push(
+          db.format(`(?,?,?,?,?,?,?,1)`, [
+            tagToAdd.id,
+            tagToAdd.name,
+            tagToAdd.name,
+            this.bid,
+            this.cid,
+            this.getWordpressId("unguess"),
+            this.getUserId(),
+          ])
+        );
       }
     }
+    if (!values.length) return;
 
     await db.query(`
     INSERT INTO wp_appq_bug_taxonomy 

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -42,18 +42,18 @@ export default class Route extends UserRoute<{
       return false;
     }
 
-    // try {
-    //   // Check if user has permission to edit the campaign
-    //   await getProjectById({
-    //     projectId: campaign.project.id,
-    //     user: this.getUser(),
-    //   });
-    // } catch (e) {
-    //   this.setError(403, {
-    //     message: ERROR_MESSAGE,
-    //   } as OpenapiError);
-    //   return false;
-    // }
+    try {
+      // Check if user has permission to edit the campaign
+      await getProjectById({
+        projectId: campaign.project.id,
+        user: this.getUser(),
+      });
+    } catch (e) {
+      this.setError(403, {
+        message: ERROR_MESSAGE,
+      } as OpenapiError);
+      return false;
+    }
     return true;
   }
 }

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -1,0 +1,77 @@
+/** OPENAPI-CLASS: patch-campaigns-cid-bug-types */
+import { ERROR_MESSAGE } from "@src/utils/constants";
+import { getCampaign } from "@src/utils/campaigns";
+import UserRoute from "@src/features/routes/UserRoute";
+import { getProjectById } from "@src/utils/projects";
+import * as db from "@src/features/db";
+import { getBugById } from "@src/utils/bugs";
+
+export default class Route extends UserRoute<{
+  parameters: StoplightOperations["patch-campaigns-cid-bugs-bid"]["parameters"]["path"];
+  body: StoplightOperations["patch-campaigns-cid-bugs-bid"]["requestBody"]["content"]["application/json"];
+  response: StoplightOperations["patch-campaigns-cid-bugs-bid"]["responses"]["200"]["content"]["application/json"];
+}> {
+  private cid: number;
+  private bid: number;
+  public tags: ({ tag_id?: number } | { tag_name?: string })[] | undefined;
+
+  constructor(configuration: RouteClassConfiguration) {
+    super(configuration);
+    const params = this.getParameters();
+    this.cid = parseInt(params.cid);
+    this.bid = parseInt(params.bid);
+    this.tags = this.getBody().tags;
+  }
+
+  protected async filter(): Promise<boolean> {
+    if (!super.filter()) return false;
+
+    const campaign = await getCampaign({ campaignId: this.cid });
+    if (!campaign) {
+      this.setError(400, {
+        status_code: 400,
+        message: ERROR_MESSAGE,
+      } as OpenapiError);
+      return false;
+    }
+
+    const bug = await getBugById({ bugId: this.bid });
+    if (!bug) {
+      this.setError(400, {
+        status_code: 400,
+        message: ERROR_MESSAGE,
+      } as OpenapiError);
+      return false;
+    }
+
+    try {
+      // Check if user has permission to edit the campaign
+      await getProjectById({
+        projectId: campaign.project.id,
+        user: this.getUser(),
+      });
+    } catch (e) {
+      this.setError(403, {
+        message: ERROR_MESSAGE,
+      } as OpenapiError);
+      return false;
+    }
+    return true;
+  }
+
+  protected async prepare(): Promise<void> {
+    const bugTags = await db.query(
+      db.format(
+        `
+      SELECT tag_id, display_name AS tag_name
+        FROM wp_appq_bug_taxonomy
+        WHERE is_public = 1 
+            AND campaign_id = ?
+            AND bug_id = ?
+        `,
+        [this.cid, this.bid]
+      )
+    );
+    return this.setSuccess(200, { tags: bugTags });
+  }
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -977,12 +977,14 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": {
-          tags?: (Partial<{
-            tag_id?: number;
-          }> &
-            Partial<{
-              tag_name?: string;
-            }>)[];
+          tags?: (
+            | {
+                tag_id: number;
+              }
+            | {
+                tag_name: string;
+              }
+          )[];
         };
       };
     };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -47,6 +47,7 @@ export interface paths {
   };
   "/campaigns/{cid}/bugs/{bid}": {
     get: operations["get-campaigns-single-bug"];
+    patch: operations["patch-campaigns-cid-bugs-bid"];
     parameters: {
       path: {
         /** Campaign id */
@@ -72,7 +73,7 @@ export interface paths {
     parameters: {
       path: {
         /** Campaign id */
-        cid: components["parameters"]["cid"];
+        cid: number;
       };
     };
   };
@@ -956,13 +957,32 @@ export interface operations {
       path: {
         /** Campaign id */
         cid: components["parameters"]["cid"];
+        /** Defines an identifier for the bug object (BUG ID) */
+        bid: components["parameters"]["bid"];
       };
     };
     responses: {
       /** OK */
       200: {
         content: {
-          "application/json": components["schemas"]["Report"][];
+          "application/json": {
+            tags?: {
+              tag_id: number;
+              tag_name: string;
+            }[];
+          };
+        };
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          tags?: (Partial<{
+            tag_id?: number;
+          }> &
+            Partial<{
+              tag_name?: string;
+            }>)[];
         };
       };
     };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -73,7 +73,7 @@ export interface paths {
     parameters: {
       path: {
         /** Campaign id */
-        cid: number;
+        cid: components["parameters"]["cid"];
       };
     };
   };
@@ -926,33 +926,7 @@ export interface operations {
       500: components["responses"]["Error"];
     };
   };
-  /** Used to extra info about a selected campaign */
-  "get-campaigns-cid-meta": {
-    parameters: {
-      path: {
-        /** Campaign id */
-        cid: number;
-      };
-    };
-    responses: {
-      /** OK */
-      200: {
-        content: {
-          "application/json": components["schemas"]["Campaign"] & {
-            selected_testers: number;
-            /** @description Array of form factors */
-            allowed_devices: string[];
-          };
-        };
-      };
-      400: components["responses"]["Error"];
-      401: components["responses"]["Error"];
-      403: components["responses"]["Error"];
-      500: components["responses"]["Error"];
-    };
-  };
-  /** Return all available report of a specific campaign */
-  "get-campaigns-reports": {
+  "patch-campaigns-cid-bugs-bid": {
     parameters: {
       path: {
         /** Campaign id */
@@ -985,6 +959,48 @@ export interface operations {
                 tag_name: string;
               }
           )[];
+        };
+      };
+    };
+  };
+  /** Used to extra info about a selected campaign */
+  "get-campaigns-cid-meta": {
+    parameters: {
+      path: {
+        /** Campaign id */
+        cid: number;
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Campaign"] & {
+            selected_testers: number;
+            /** @description Array of form factors */
+            allowed_devices: string[];
+          };
+        };
+      };
+      400: components["responses"]["Error"];
+      401: components["responses"]["Error"];
+      403: components["responses"]["Error"];
+      500: components["responses"]["Error"];
+    };
+  };
+  /** Return all available report of a specific campaign */
+  "get-campaigns-reports": {
+    parameters: {
+      path: {
+        /** Campaign id */
+        cid: components["parameters"]["cid"];
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Report"][];
         };
       };
     };


### PR DESCRIPTION
PATCH /campaigns/{cid}/bugs/{bid}
- 


  -  request body: ( { tag_id: number } | { tag_name: string } ) [ ]
  -  response body: { tag_id: number, tag_name: string } [ ]


Tests:
- 
- Should answer 403 if user is not logged in
- Should fail if the campaign does not exist
- Should fail if the bug does not exist
- Should fail if the user is not the owner
- Should remove all tags if send empty tags
- Should add existing tag by tag_id
- Should add existing tag by tag_name
- Should add tag by tag_name if tag does not exists
- Should ignore duplicated tag_id